### PR TITLE
Modify project explorer API for ESB configs

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/syntaxmodel/directoryTree/DirectoryMap.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/syntaxmodel/directoryTree/DirectoryMap.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class DirectoryMap {
 
-    HashMap<String, List<SimpleComponent>> esbConfigs;
+    List<ESBComponent> esbConfigs;
     List<SimpleComponent> dataServiceConfigs;
     List<SimpleComponent> dataSourceConfigs;
     List<SimpleComponent> mediatorProjects;
@@ -38,16 +38,7 @@ public class DirectoryMap {
 
     public DirectoryMap() {
 
-        this.esbConfigs = new HashMap<>();
-        List<String> esbKeys = new ArrayList<>(Arrays.asList(
-                "api", "endpoints", "inbound-endpoints", "message-processors",
-                "local-entries", "message-stores", "proxy-services", "sequences",
-                "tasks", "templates"
-        ));
-        for (String key : esbKeys) {
-            esbConfigs.put(key, new ArrayList<>());
-        }
-
+        this.esbConfigs = new ArrayList<>();
         this.dataServiceConfigs = new ArrayList<>();
         this.dataSourceConfigs = new ArrayList<>();
         this.mediatorProjects = new ArrayList<>();
@@ -59,15 +50,9 @@ public class DirectoryMap {
         this.kubernetesExporters = new ArrayList<>();
     }
 
-    public void addEsbComponent(String type, SimpleComponent component) {
+    public void addEsbComponent(ESBComponent esbComponent) {
 
-        esbConfigs.get(type).add(component);
-    }
-
-    public void addEsbComponent(String type, String name, String path) {
-
-        AdvancedComponent advancedComponent = new AdvancedComponent(type, name, path);
-        esbConfigs.get(type).add(advancedComponent);
+        esbConfigs.add(esbComponent);
     }
 
     public void addDataServiceConfig(String type, String name, String path) {
@@ -124,7 +109,7 @@ public class DirectoryMap {
         kubernetesExporters.add(component);
     }
 
-    public HashMap<String, List<SimpleComponent>> getEsbConfigs() {
+    public List<ESBComponent> getEsbConfigs() {
 
         return esbConfigs;
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/syntaxmodel/directoryTree/ESBComponent.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/syntaxmodel/directoryTree/ESBComponent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.syntaxmodel.directoryTree;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public class ESBComponent extends SimpleComponent {
+
+    HashMap<String, List<SimpleComponent>> esbConfigs;
+
+    public ESBComponent(String type, String name, String path) {
+
+        super(type, name, path);
+        this.esbConfigs = new HashMap<>();
+        List<String> esbKeys = new ArrayList<>(Arrays.asList(
+                "api", "endpoints", "inbound-endpoints", "message-processors",
+                "local-entries", "message-stores", "proxy-services", "sequences",
+                "tasks", "templates"
+        ));
+        for (String key : esbKeys) {
+            esbConfigs.put(key, new ArrayList<>());
+        }
+    }
+
+    public void addEsbConfig(String type, SimpleComponent component) {
+
+        esbConfigs.get(type).add(component);
+    }
+}


### PR DESCRIPTION
Currently all the esb configs are aggregated and shown in the project explorer. This commit modifies the LS to differentiate the ESB configs.