### PR TITLE
Add node position details in syntax tree

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/Range.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/Range.java
@@ -20,32 +20,32 @@ package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo;
 
 public class Range {
 
-    Position start;
-    Position end;
+    TagRange startTagRange;
+    TagRange endTagRange;
 
-    public Range(Position start, Position end) {
+    public Range(TagRange startTagRange, TagRange endTagRange) {
 
-        this.start = start;
-        this.end = end;
+        this.startTagRange = startTagRange;
+        this.endTagRange = endTagRange;
     }
 
-    public Position getStart() {
+    public TagRange getStartTagRange() {
 
-        return start;
+        return startTagRange;
     }
 
-    public void setStart(Position start) {
+    public void setStartTagRange(TagRange startTagRange) {
 
-        this.start = start;
+        this.startTagRange = startTagRange;
     }
 
-    public Position getEnd() {
+    public TagRange getEndTagRange() {
 
-        return end;
+        return endTagRange;
     }
 
-    public void setEnd(Position end) {
+    public void setEndTagRange(TagRange endTagRange) {
 
-        this.end = end;
+        this.endTagRange = endTagRange;
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/STNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/STNode.java
@@ -18,8 +18,11 @@
 
 package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo;
 
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lsp4j.Position;
 
 public class STNode {
 
@@ -41,30 +44,29 @@ public class STNode {
         }
     }
 
-    private Range findRange(DOMNode node) {
+    private Range findRange(DOMElement node) {
 
-        String content = node.getOwnerDocument().getTextDocument().getText();
-        Position startposition = findLineCharPosition(content, node.getStart());
-        Position endposition = findLineCharPosition(content, node.getEnd());
-        return new Range(startposition, endposition);
-    }
+        int startTagOpenOffset = node.getStartTagOpenOffset();
+        int startTagCloseOffset = node.getOffsetBeforeCloseOfStartTag();
+        int endTagOpenOffset = node.getEndTagOpenOffset();
+        int endTagCloseOffset = node.getEndTagCloseOffset();
 
-    private static Position findLineCharPosition(String content, int offset) {
-
-        int line = 0;
-        int character = 0;
-        for (int i = 0; i < offset; i++) {
-            char currentChar = content.charAt(i);
-
-            if (currentChar == '\n') {
-                line++;
-                character = 0;
-            } else {
-                character++;
-            }
+        DOMDocument document = node.getOwnerDocument();
+        Position startTagOpenPosition = null;
+        Position startTagClosePosition = null;
+        Position endTagOpenPosition = null;
+        Position endTagClosePosition = null;
+        try {
+            startTagOpenPosition = document.positionAt(startTagOpenOffset);
+            startTagClosePosition = document.positionAt(startTagCloseOffset);
+            endTagOpenPosition = document.positionAt(endTagOpenOffset);
+            endTagClosePosition = document.positionAt(endTagCloseOffset);
+        } catch (BadLocationException e) {
         }
+        TagRange startTagRange = new TagRange(startTagOpenPosition, startTagClosePosition);
+        TagRange endTagRange = new TagRange(endTagOpenPosition, endTagClosePosition);
 
-        return new Position(line, character);
+        return new Range(startTagRange, endTagRange);
     }
 
     public String getTag() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/TagRange.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/TagRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,36 @@
 
 package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo;
 
-public class Position {
+import org.eclipse.lsp4j.Position;
 
-    long line;
-    long character;
+public class TagRange {
 
-    public Position(long line, long character) {
+    private Position start;
+    private Position end;
 
-        this.line = line;
-        this.character = character;
+    public TagRange(Position start, Position end) {
+
+        this.start = start;
+        this.end = end;
+    }
+
+    public Position getStart() {
+
+        return start;
+    }
+
+    public void setStart(Position start) {
+
+        this.start = start;
+    }
+
+    public Position getEnd() {
+
+        return end;
+    }
+
+    public void setEnd(Position end) {
+
+        this.end = end;
     }
 }


### PR DESCRIPTION
This PR improves the tag position details. Previously the syntax tree nodes had only the start tag position of open tag and end tag position of close tag. This PR adds the start and end location of both tags.