### PR TITLE
Skip Validation of XML Schema

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xerces/LSPXMLEntityManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xerces/LSPXMLEntityManager.java
@@ -105,6 +105,15 @@ public class LSPXMLEntityManager extends XMLEntityManager {
 			}
 		}
 
+		// 1. Skipping the setting of DTD files as we don't need to validate XSD using DTD (To skip error when trying
+		// to fetch dtd schema from "http://www.w3.org/2001/XMLSchema").
+		//2. return an empty string to avoid breaking syntax validation.
+		if (DOMUtils.isDTD(systemId)) {
+			XMLInputSource in = new XMLInputSource(xmlInputSource.getPublicId(), xmlInputSource.getSystemId(),
+					xmlInputSource.getBaseSystemId(), new StringReader(""), null);
+			return super.setupCurrentEntity(name, in, literal, isExternal);
+		}
+
 		try {
 			return super.setupCurrentEntity(name, xmlInputSource, literal, isExternal);
 		} catch (Exception e) {


### PR DESCRIPTION
The XML parser validates the XSD schemas using "http://www.w3.org/2001/XMLSchema". It tries to fetch the dtd schema instead of using it from cache. Additionally, we don't need to validate the xsd schemas as they are static files. So, here the XSD validation is removed.