### PR TITLE
Add method to get available resources

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -19,6 +19,9 @@
 package org.eclipse.lemminx;
 
 import org.eclipse.lemminx.customservice.ISynapseLanguageService;
+import org.eclipse.lemminx.customservice.synapse.resourceFinder.ResourceFinder;
+import org.eclipse.lemminx.customservice.synapse.resourceFinder.ResourceParam;
+import org.eclipse.lemminx.customservice.synapse.resourceFinder.ResourceResponse;
 import org.eclipse.lemminx.customservice.synapse.definition.SynapseDefinitionProvider;
 import org.eclipse.lemminx.customservice.synapse.directoryTree.DirectoryMapResponse;
 import org.eclipse.lemminx.customservice.synapse.directoryTree.DirectoryTreeBuilder;
@@ -87,6 +90,15 @@ public class SynapseLanguageService implements ISynapseLanguageService {
         return xmlTextDocumentService.computeDOMAsync(params.getTextDocument(), (xmlDocument, cancelChecker) -> {
             Location location = SynapseDefinitionProvider.definition(xmlDocument, params.getPosition(), cancelChecker);
             return location;
+        });
+    }
+
+    @Override
+    public CompletableFuture<ResourceResponse> availableResources(ResourceParam param) {
+
+        return xmlTextDocumentService.computeDOMAsync(param.documentIdentifier, (xmlDocument, cancelChecker) -> {
+            ResourceResponse response = ResourceFinder.getAvailableResources(xmlDocument, param.resourceType);
+            return response;
         });
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.lemminx.customservice;
 
+import org.eclipse.lemminx.customservice.synapse.resourceFinder.ResourceParam;
+import org.eclipse.lemminx.customservice.synapse.resourceFinder.ResourceResponse;
 import org.eclipse.lemminx.customservice.synapse.directoryTree.DirectoryMapResponse;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.SyntaxTreeResponse;
 import org.eclipse.lsp4j.DefinitionParams;
@@ -44,4 +46,7 @@ public interface ISynapseLanguageService {
 
     @JsonRequest
     CompletableFuture<Location> definition(DefinitionParams params);
+
+    @JsonRequest
+    CompletableFuture<ResourceResponse> availableResources(ResourceParam param);
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/Resource.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/Resource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.resourceFinder;
+
+public class Resource {
+
+    private String name;
+    private String type;
+    private String from;
+    private String path;
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getType() {
+
+        return type;
+    }
+
+    public void setType(String type) {
+
+        this.type = type;
+    }
+
+    public String getFrom() {
+
+        return from;
+    }
+
+    public void setFrom(String from) {
+
+        this.from = from;
+    }
+
+    public String getPath() {
+
+        return path;
+    }
+
+    public void setPath(String path) {
+
+        this.path = path;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceFinder.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.resourceFinder;
+
+import org.eclipse.lemminx.customservice.synapse.directoryTree.legacyBuilder.utils.ProjectType;
+import org.eclipse.lemminx.customservice.synapse.utils.Constant;
+import org.eclipse.lemminx.customservice.synapse.utils.LegacyConfigFinder;
+import org.eclipse.lemminx.customservice.synapse.utils.Utils;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMElement;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class ResourceFinder {
+
+    private static final Logger LOGGER = Logger.getLogger(ResourceFinder.class.getName());
+    private static final String ARTIFACTS = "ARTIFACTS";
+
+    public static ResourceResponse getAvailableResources(DOMDocument xmlDocument, String resourceType) {
+
+        ResourceResponse response = new ResourceResponse();
+        Boolean isLegacyProject = Utils.isLegacyProject(xmlDocument);
+        try {
+            String projectRootPath = Utils.findProjectRootPath(xmlDocument.getDocumentURI(), isLegacyProject);
+            if (projectRootPath != null) {
+                List<Resource> resources = findResources(projectRootPath, resourceType, isLegacyProject);
+                response.setResources(resources);
+            }
+        } catch (IOException e) {
+            LOGGER.warning("Error while finding project root path");
+        }
+        return response;
+    }
+
+    private static List<Resource> findResources(String projectPath, String type, Boolean isLegacyProject) {
+
+        if (isLegacyProject) {
+            return findResourcesInLegacyProject(projectPath, type);
+        }
+        return findResources(projectPath, type);
+    }
+
+    private static List<Resource> findResources(String projectPath, String type) {
+
+        List<Resource> resources = new ArrayList<>();
+        Path artifactsPath = Path.of(projectPath, "src", "main", "wso2mi", "artifacts");
+        List<Resource> resourcesInArtifacts = findResourceInArtifacts(artifactsPath, type);
+        resources.addAll(resourcesInArtifacts);
+
+        return resources;
+    }
+
+    private static List<Resource> findResourcesInLegacyProject(String projectPath, String type) {
+
+        List<Resource> resources = new ArrayList<>();
+        try {
+            List<String> esbConfigPaths = LegacyConfigFinder.getConfigPaths(projectPath, ProjectType.ESB_CONFIGS.value);
+            for (String esbConfigPath : esbConfigPaths) {
+                Path artifactPath = Path.of(esbConfigPath, "src", "main", "synapse-config");
+                List<Resource> resourceInArtifacts = findResourceInArtifacts(artifactPath, type);
+                resources.addAll(resourceInArtifacts);
+            }
+        } catch (IOException e) {
+            LOGGER.warning("Error while finding resources in legacy project");
+        }
+
+        return resources;
+    }
+
+    private static List<Resource> findResourceInArtifacts(Path artifactsPath, String type) {
+
+        List<Resource> resources = new ArrayList<>();
+        String resourceTypeFolder = processType(type);
+        if (resourceTypeFolder != null) {
+            Path resourceFolderPath = Path.of(artifactsPath.toString(), resourceTypeFolder);
+            File folder = new File(resourceFolderPath.toString());
+            File[] listOfFiles = folder.listFiles();
+            if (listOfFiles != null) {
+                List<Resource> resources1 = createResources(List.of(listOfFiles), type, ARTIFACTS);
+                resources.addAll(resources1);
+            }
+        }
+        return resources;
+    }
+
+    private static String processType(String type) {
+
+        if (Constant.ENDPOINT.equalsIgnoreCase(type)) {
+            return "endpoints";
+        } else if (Constant.SEQUENCE.equalsIgnoreCase(type)) {
+            return "sequences";
+        } else if (Constant.MESSAGE_STORE.equalsIgnoreCase(type)) {
+            return "message-stores";
+        } else if (Constant.MESSAGE_PROCESSOR.equalsIgnoreCase(type)) {
+            return "message-processors";
+        } else if (Constant.TEMPLATE.equalsIgnoreCase(type)) {
+            return "templates";
+        } else if (Constant.TASK.equalsIgnoreCase(type)) {
+            return "tasks";
+        }
+        return null;
+    }
+
+    private static List<Resource> createResources(List<File> files, String type, String from) {
+
+        List<Resource> resources = new ArrayList<>();
+        for (File file : files) {
+            Resource resource = createResource(file, type, from);
+            if (resource != null) {
+                resources.add(resource);
+            }
+        }
+        return resources;
+    }
+
+    private static Resource createResource(File file, String type, String from) {
+
+        try {
+            DOMDocument document = Utils.getDOMDocument(file);
+            DOMElement rootElement = Utils.getRootElementFromConfigXml(document);
+            if (checkType(rootElement, type)) {
+                Resource resource = new Resource();
+                resource.setName(rootElement.getAttribute(Constant.NAME));
+                resource.setType(Utils.addUnderscoreBetweenWords(type).toUpperCase());
+                resource.setFrom(from);
+                resource.setPath(file.getAbsolutePath());
+                return resource;
+            }
+        } catch (IOException e) {
+            LOGGER.warning("Error while reading file: " + file.getName() + " to create resource object");
+        }
+        return null;
+    }
+
+    private static boolean checkType(DOMElement rootElement, String type) {
+
+        String elementType = rootElement.getNodeName();
+        return type.equalsIgnoreCase(elementType);
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceParam.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceParam.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.resourceFinder;
+
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+public class ResourceParam {
+
+    public TextDocumentIdentifier documentIdentifier;
+    public String resourceType;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceResponse.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.resourceFinder;
+
+import java.util.List;
+
+public class ResourceResponse {
+
+    private List<Resource> resources;
+
+    public List<Resource> getResources() {
+
+        return resources;
+    }
+
+    public void setResources(List<Resource> resources) {
+
+        this.resources = resources;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/LegacyConfigFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/LegacyConfigFinder.java
@@ -71,7 +71,7 @@ public class LegacyConfigFinder {
         return null;
     }
 
-    private static List<String> getConfigPaths(String projectPath, String configType) throws IOException {
+    public static List<String> getConfigPaths(String projectPath, String configType) throws IOException {
 
         File file = new File(projectPath);
         File[] listOfFiles = file.listFiles(File::isDirectory);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -90,7 +90,7 @@ public class Utils {
         return domDocument;
     }
 
-    public static DOMElement getRootElementFromConfigXml(DOMDocument document) {
+    public static DOMElement getRootElementFromConfigXml(DOMNode document) {
 
         DOMElement rootElement = null;
         for (int i = 0; i < document.getChildren().size(); i++) {


### PR DESCRIPTION
This method returns all the available resources in a specific type such as "sequences", "endpoints", etc. The extension can access this method through "synapse/availableResource". The parameters of this method are TextDocumentIdentifier of the document, and the resource type that is needed.