### PR TITLE
Fix missing elements in syntax tree

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/TemplateFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/TemplateFactory.java
@@ -44,7 +44,7 @@ public class TemplateFactory extends AbstractFactory {
         if (children != null && !children.isEmpty()) {
             for (DOMNode child : children) {
                 String name = child.getNodeName();
-                if (name.equalsIgnoreCase(Constant.PARAMETER)) {
+                if (name.contains(Constant.PARAMETER)) {
                     TemplateParameter parameter = createTemplateParameter(child);
                     parameters.add(parameter);
                 } else if (name.equalsIgnoreCase(Constant.ENDPOINT)) {
@@ -57,6 +57,7 @@ public class TemplateFactory extends AbstractFactory {
                     template.setSequence(sequence);
                 }
             }
+            template.setParameter(parameters.toArray(new TemplateParameter[parameters.size()]));
         }
         return template;
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/endpoint/EndpointFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/endpoint/EndpointFactory.java
@@ -99,7 +99,7 @@ public class EndpointFactory extends AbstractFactory {
                 } else if (name.equalsIgnoreCase(Constant.PROPERTY)) {
                     EndpointProperty property = createEndpointProperty(node);
                     properties.add(property);
-                } else if (name.equalsIgnoreCase(Constant.PARAMETER)) {
+                } else if (name.contains(Constant.PARAMETER)) {
                     EndpointParameter parameter = createEndpointParameter(node);
                     parameters.add(parameter);
                 } else if (name.equalsIgnoreCase(Constant.DESCRIPTION)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/endpoint/EndpointUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/endpoint/EndpointUtils.java
@@ -23,6 +23,7 @@ import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointEnableRM;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointEnableSec;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointMarkForSuspension;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointRetryConfig;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointSuspendOnFailure;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointTimeout;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.http.EndpointHttpAuthenticationOauthRequestParameters;
@@ -167,5 +168,24 @@ public class EndpointUtils {
             requestParameters.setParameter(parameters.toArray(new Parameter[parameters.size()]));
         }
         return requestParameters;
+    }
+
+    public static EndpointRetryConfig createRetryConfig(DOMNode node) {
+
+        EndpointRetryConfig retryConfig = new EndpointRetryConfig();
+        List<DOMNode> children = node.getChildren();
+        if (children != null && !children.isEmpty()) {
+            for (DOMNode child : children) {
+                String name = child.getNodeName();
+                STNode stNode = new STNode();
+                stNode.elementNode((DOMElement) child);
+                if (Constant.ENABLED_ERROR_CODES.equalsIgnoreCase(name)) {
+                    retryConfig.setEnabledErrorCodes(stNode);
+                } else if (Constant.DISABLED_ERROR_CODES.equalsIgnoreCase(name)) {
+                    retryConfig.setDisabledErrorCodes(stNode);
+                }
+            }
+        }
+        return retryConfig;
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/endpoint/HttpEndpointFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/endpoint/HttpEndpointFactory.java
@@ -24,6 +24,7 @@ import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointEnableRM;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointEnableSec;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointMarkForSuspension;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointRetryConfig;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointSuspendOnFailure;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointTimeout;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.http.EnableSecAndEnableRMAndEnableAddressing;
@@ -76,6 +77,9 @@ public class HttpEndpointFactory extends AbstractFactory {
                 } else if (name.equalsIgnoreCase(Constant.AUTHENTICATION)) {
                     EndpointHttpAuthentication authentication = createAuthentication(node);
                     configs.setAuthentication(Optional.ofNullable(authentication));
+                } else if (Constant.RETRY_CONFIG.equalsIgnoreCase(name)) {
+                    EndpointRetryConfig retryConfig = EndpointUtils.createRetryConfig(node);
+                    configs.setRetryConfig(Optional.ofNullable(retryConfig));
                 }
             }
             httpEndpoint.setEnableSecAndEnableRMAndEnableAddressing(configs);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/mediators/core/CallFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/mediators/core/CallFactory.java
@@ -75,6 +75,8 @@ public class CallFactory extends AbstractMediatorFactory {
         String initAxis2ClientOptions = element.getAttribute(Constant.INIT_AXIS2_CLIENT_OPTIONS);
         if (initAxis2ClientOptions != null) {
             ((Call) node).setInitAxis2ClientOptions(Boolean.parseBoolean(initAxis2ClientOptions));
+        } else {
+            ((Call) node).setInitAxis2ClientOptions(Boolean.TRUE);
         }
         String description = element.getAttribute(Constant.DESCRIPTION);
         if (description != null) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/mediators/eip/AggregateFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/mediators/eip/AggregateFactory.java
@@ -139,7 +139,7 @@ public class AggregateFactory extends AbstractMediatorFactory {
 
         List<DOMNode> children = child.getChildren();
         List<Mediator> mediators = SyntaxTreeUtils.createMediators(children);
-        onComplete.setMediators(mediators);
+        onComplete.setMediatorList(mediators);
         return onComplete;
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/endpoint/common/EndpointRetryConfig.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/endpoint/common/EndpointRetryConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+
+public class EndpointRetryConfig {
+
+    STNode enabledErrorCodes;
+    STNode disabledErrorCodes;
+
+    public STNode getEnabledErrorCodes() {
+
+        return enabledErrorCodes;
+    }
+
+    public void setEnabledErrorCodes(STNode enabledErrorCodes) {
+
+        this.enabledErrorCodes = enabledErrorCodes;
+    }
+
+    public STNode getDisabledErrorCodes() {
+
+        return disabledErrorCodes;
+    }
+
+    public void setDisabledErrorCodes(STNode disabledErrorCodes) {
+
+        this.disabledErrorCodes = disabledErrorCodes;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/endpoint/http/EnableSecAndEnableRMAndEnableAddressing.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/endpoint/http/EnableSecAndEnableRMAndEnableAddressing.java
@@ -23,6 +23,7 @@ import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointEnableRM;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointEnableSec;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointMarkForSuspension;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointRetryConfig;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointSuspendOnFailure;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.endpoint.common.EndpointTimeout;
 
@@ -37,6 +38,7 @@ public class EnableSecAndEnableRMAndEnableAddressing extends STNode {
     Optional<EndpointSuspendOnFailure> suspendOnFailure;
     Optional<EndpointMarkForSuspension> markForSuspension;
     Optional<EndpointHttpAuthentication> authentication;
+    Optional<EndpointRetryConfig> retryConfig;
 
     public Optional<EndpointEnableSec> getEnableSec() {
 
@@ -106,5 +108,15 @@ public class EnableSecAndEnableRMAndEnableAddressing extends STNode {
     public void setAuthentication(Optional<EndpointHttpAuthentication> authentication) {
 
         this.authentication = authentication;
+    }
+
+    public Optional<EndpointRetryConfig> getRetryConfig() {
+
+        return retryConfig;
+    }
+
+    public void setRetryConfig(Optional<EndpointRetryConfig> retryConfig) {
+
+        this.retryConfig = retryConfig;
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/mediator/eip/aggregate/AggregateOnComplete.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/mediator/eip/aggregate/AggregateOnComplete.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 public class AggregateOnComplete extends STNode {
 
-    List<Mediator> mediators;
+    List<Mediator> mediatorList;
     String expression;
     String sequenceAttribute;
     String enclosingElementProperty;
@@ -34,17 +34,17 @@ public class AggregateOnComplete extends STNode {
 
     public AggregateOnComplete() {
 
-        mediators = new ArrayList<>();
+        mediatorList = new ArrayList<>();
     }
 
-    public List<Mediator> getMediators() {
+    public List<Mediator> getMediatorList() {
 
-        return mediators;
+        return mediatorList;
     }
 
-    public void setMediators(List<Mediator> mediators) {
+    public void setMediatorList(List<Mediator> mediatorList) {
 
-        this.mediators = mediators;
+        this.mediatorList = mediatorList;
     }
 
     public String getExpression() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -420,4 +420,7 @@ public class Constant {
     public static final String COMPONENT = "component";
     public static final String INCLUDE = "include";
     public static final String KEY_EXPRESSION = "key-expression";
+    public static final String RETRY_CONFIG = "retryConfig";
+    public static final String ENABLED_ERROR_CODES = "enabledErrorCodes";
+    public static final String DISABLED_ERROR_CODES = "disabledErrorCodes";
 }


### PR DESCRIPTION
Some of the elements are missing from the syntax tree of mediators and endpoints. This PR adds those missing attributes and elements.