### PR TITLE
Fix directory tree

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/directoryTree/DirectoryTreeBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/directoryTree/DirectoryTreeBuilder.java
@@ -350,6 +350,10 @@ public class DirectoryTreeBuilder {
 
         File file = new File(path);
         DOMDocument domDocument = Utils.getDOMDocument(file);
+
+        if ("ProxyService".equalsIgnoreCase(type)) type = Constant.PROXY;
+        if ("DataService".equalsIgnoreCase(type)) type = Constant.DATA;
+
         DOMNode node = Utils.getChildNodeByName(domDocument, type);
         if (node != null) {
             String name = node.getAttribute(Constant.NAME);


### PR DESCRIPTION
The directory tree builder is failing to add proxy services and data-services to the directory tree. This commit fixes it.