### PR TITLE
Add a file watcher to connector folder

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -141,6 +141,11 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     public void updateConnectors(TextDocumentIdentifier param) {
 
         String uri = param.getUri();
+        updateConnectors(uri);
+    }
+
+    public static void updateConnectors(String uri) {
+
         MediatorFactoryFinder.getInstance().updateConnectors(uri);
 
         //Generate xsd schema for the available connectors and write it to the schema file.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLWorkspaceService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLWorkspaceService.java
@@ -93,8 +93,12 @@ public class XMLWorkspaceService implements WorkspaceService, IXMLCommandService
 				.getTextDocumentService();
 		List<FileEvent> changes = params.getChanges();
 		for (FileEvent change : changes) {
-			if (!xmlTextDocumentService.documentIsOpen(change.getUri())) {
-				xmlTextDocumentService.doSave(change.getUri());
+			if (change.getUri().contains("connectors") && change.getUri().contains(".zip")) {
+				SynapseLanguageService.updateConnectors(change.getUri());
+			} else {
+				if (!xmlTextDocumentService.documentIsOpen(change.getUri())) {
+					xmlTextDocumentService.doSave(change.getUri());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
A file watcher will be added to the extension in the start of the LS to the connector folder of the current project. It will watch for connector zip changes and notify the LS to update the loaded connectors and connector schema.