### PR TITLE
Fix get available templates

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceFinder.java
@@ -253,7 +253,7 @@ public class ResourceFinder {
             DOMElement rootElement;
             String nodeName = typeToXmlTagMap.get(type);
             rootElement = (DOMElement) Utils.getChildNodeByName(document, nodeName);
-            if (rootElement != null) {
+            if (rootElement != null && checkValid(rootElement, type)) {
                 Resource resource = null;
                 if (ARTIFACTS.equals(from)) {
                     resource = createArtifactResource(file, rootElement, type);
@@ -266,6 +266,26 @@ public class ResourceFinder {
             LOGGER.warning("Error while reading file: " + file.getName() + " to create resource object");
         }
         return null;
+    }
+
+    private static boolean checkValid(DOMElement rootElement, String type) {
+
+        String nodeName = rootElement.getNodeName();
+        if (Constant.TEMPLATE.equals(nodeName)) {
+            if ("sequenceTemplate".equals(type)) {
+                DOMElement sequenceElement = (DOMElement) Utils.getChildNodeByName(rootElement, Constant.SEQUENCE);
+                if (sequenceElement != null) {
+                    return true;
+                }
+            } else if ("endpointTemplate".equals(type)) {
+                DOMElement endpointElement = (DOMElement) Utils.getChildNodeByName(rootElement, Constant.ENDPOINT);
+                if (endpointElement != null) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
     }
 
     private static Resource createArtifactResource(File file, DOMElement rootElement, String type) {


### PR DESCRIPTION
getAvailableResources method returns all the templates available when trying to get sequenceTemplate or endpointTemplate. This commit fixes it by filtering sequence templates and endpoint templates.