### PR TITLE
Add config key to connector schema

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/SchemaGenerate.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/SchemaGenerate.java
@@ -90,6 +90,7 @@ public class SchemaGenerate {
         StringBuilder sb = new StringBuilder();
         for (Connector conn : connectors) {
             List<ConnectorAction> actions = conn.getActions();
+            boolean canHaveConnection = canHaveConnection(conn);
             for (ConnectorAction action : actions) {
                 if (!action.getHidden()) {
                     sb.append("            <xs:element name=\"" + action.getTag() + "\">\n");
@@ -99,12 +100,25 @@ public class SchemaGenerate {
                         sb.append("                        <xs:element name=\"" + parameter + "\" type=\"xs:string\" " +
                                 "minOccurs=\"0\" maxOccurs=\"1\" />\n");
                     }
-                    sb.append("                    </xs:all>\n" +
-                            "                </xs:complexType>\n" +
+                    sb.append("                    </xs:all>\n");
+                    if (canHaveConnection) {
+                        sb.append("                    <xs:attribute name=\"configKey\" type=\"xs:string\"/>\n");
+                    }
+                    sb.append("                </xs:complexType>\n" +
                             "            </xs:element>\n");
                 }
             }
         }
         return sb.toString();
+    }
+
+    private static boolean canHaveConnection(Connector conn) {
+
+        for (ConnectorAction action : conn.getActions()) {
+            if (action.getTag().contains("init") && action.getHidden()) {
+                return Boolean.TRUE;
+            }
+        }
+        return Boolean.FALSE;
     }
 }


### PR DESCRIPTION
Connectors that have connection allows to add an attribute called configKey to each of its operation. This PR modifies the connector schema generator to identify the connectors that can have connection and add configKey attribute to those schema elements.