### PR TITLE
Fix null pointer exception for no connector folder

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/ConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/ConnectorLoader.java
@@ -69,8 +69,8 @@ public class ConnectorLoader {
             tempFolder.mkdirs();
         }
         List<File> connectorZips = new ArrayList<>();
-        if (connectorsFolderPath != null) {
-            File folder = new File(connectorsFolderPath);
+        File folder = new File(connectorsFolderPath);
+        if (connectorsFolderPath != null && folder.exists()) {
             File[] files = folder.listFiles();
             for (File f : files) {
                 if (Utils.isZipFile(f)) {


### PR DESCRIPTION
The LS is throwing null pointer exception when there is no connector folder in the project. This PR fixes it.