### PR TITLE
Remove find project root path method

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -91,6 +91,7 @@ public class SynapseLanguageService implements ISynapseLanguageService {
 
         return xmlTextDocumentService.computeDOMAsync(param, (xmlDocument, cancelChecker) -> {
             SyntaxTreeGenerator generator = new SyntaxTreeGenerator();
+            generator.setProjectPath(projectUri);
             return generator.getSyntaxTree(xmlDocument);
         });
     }
@@ -123,7 +124,8 @@ public class SynapseLanguageService implements ISynapseLanguageService {
             DefinitionParams params) {
 
         return xmlTextDocumentService.computeDOMAsync(params.getTextDocument(), (xmlDocument, cancelChecker) -> {
-            Location location = SynapseDefinitionProvider.definition(xmlDocument, params.getPosition(), cancelChecker);
+            Location location = SynapseDefinitionProvider.definition(xmlDocument, params.getPosition(), projectUri,
+                    cancelChecker);
             return location;
         });
     }
@@ -131,12 +133,7 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     @Override
     public CompletableFuture<ResourceResponse> availableResources(ResourceParam param) {
 
-        String uri = param.documentIdentifier.getUri();
-        if (uri == null) {
-            uri = projectUri;
-        }
-        ResourceResponse response = ResourceFinder.getAvailableResources(uri,
-                param.resourceType);
+        ResourceResponse response = ResourceFinder.getAvailableResources(projectUri, param.resourceType);
         return CompletableFuture.supplyAsync(() -> response);
     }
 
@@ -178,14 +175,14 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     @Override
     public CompletableFuture<List<String>> getRegistryFiles(TextDocumentIdentifier param) {
 
-        List<String> registryFiles = RegistryFileScanner.scanRegistryFiles(param.getUri());
+        List<String> registryFiles = RegistryFileScanner.scanRegistryFiles(projectUri);
         return CompletableFuture.supplyAsync(() -> registryFiles);
     }
 
     @Override
     public CompletableFuture<List<String>> getArtifactFiles(TextDocumentIdentifier param) {
 
-        List<String> artifactFiles = ArtifactFileScanner.scanArtifactFiles(param.getUri());
+        List<String> artifactFiles = ArtifactFileScanner.scanArtifactFiles(projectUri);
         return CompletableFuture.supplyAsync(() -> artifactFiles);
     }
 
@@ -211,7 +208,7 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     public CompletableFuture<Either<Connections, Map<String, Connections>>> connectorConnections(ConnectorParam param) {
 
         Either<Connections, Map<String, Connections>> connections =
-                ConnectionFinder.findConnections(param.documentIdentifier.getUri(), param.connectorName);
+                ConnectionFinder.findConnections(projectUri, param.connectorName);
         return CompletableFuture.supplyAsync(() -> connections);
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLWorkspaceService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLWorkspaceService.java
@@ -94,7 +94,8 @@ public class XMLWorkspaceService implements WorkspaceService, IXMLCommandService
 		List<FileEvent> changes = params.getChanges();
 		for (FileEvent change : changes) {
 			if (change.getUri().contains("connectors") && change.getUri().contains(".zip")) {
-				SynapseLanguageService.updateConnectors(change.getUri());
+				String projectUri = xmlLanguageServer.synapseLanguageService.getProjectUri();
+				SynapseLanguageService.updateConnectors(projectUri);
 			} else {
 				if (!xmlTextDocumentService.documentIsOpen(change.getUri())) {
 					xmlTextDocumentService.doSave(change.getUri());

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/ConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/ConnectorLoader.java
@@ -345,9 +345,8 @@ public class ConnectorLoader {
         }
     }
 
-    private void setConnectorsFolderPath(String projectPath) {
+    private void setConnectorsFolderPath(String projectRoot) {
 
-        String projectRoot = Utils.findProjectRootPath(projectPath);
         if (projectRoot != null) {
             if (legacyMode) {
                 File projectFile = new File(projectRoot);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/directoryTree/legacyBuilder/LegacyDirectoryTreeBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/directoryTree/legacyBuilder/LegacyDirectoryTreeBuilder.java
@@ -46,15 +46,9 @@ public class LegacyDirectoryTreeBuilder {
 
     public static DirectoryMapResponse buildDirectoryTree(WorkspaceFolder workspaceFolder) {
 
-        String currentPath = workspaceFolder.getUri();
+        String rootPath = workspaceFolder.getUri();
         DirectoryMap directoryMap = new DirectoryMap();
 
-        String rootPath = null;
-        try {
-            rootPath = Utils.findProjectRootPath(currentPath, Boolean.TRUE);
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Error while reading file content", e);
-        }
         projectPath = rootPath;
         if (projectPath != null) {
             analyze(directoryMap);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ArtifactFileScanner.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ArtifactFileScanner.java
@@ -18,8 +18,6 @@
 
 package org.eclipse.lemminx.customservice.synapse.resourceFinder;
 
-import org.eclipse.lemminx.customservice.synapse.utils.Utils;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -29,9 +27,8 @@ import java.util.regex.Pattern;
 
 public class ArtifactFileScanner {
 
-    public static List<String> scanArtifactFiles(String path) {
+    public static List<String> scanArtifactFiles(String projectPath) {
 
-        String projectPath = Utils.findProjectRootPath(path);
         List<String> artifactFiles = new ArrayList<>();
         if (projectPath != null) {
             String artifactPath = Path.of(projectPath, "src", "main", "wso2mi", "artifacts").toString();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/RegistryFileScanner.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/RegistryFileScanner.java
@@ -18,8 +18,6 @@
 
 package org.eclipse.lemminx.customservice.synapse.resourceFinder;
 
-import org.eclipse.lemminx.customservice.synapse.utils.Utils;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -69,9 +67,8 @@ public class RegistryFileScanner {
         return "";
     }
 
-    private static String getRegistryPath(String path) {
+    private static String getRegistryPath(String projectPath) {
 
-        String projectPath = Utils.findProjectRootPath(path);
         if (projectPath != null) {
             Path registryPath = Path.of(projectPath, "src", "main", "wso2mi", "resources", "registry");
             return registryPath.toString();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceFinder.java
@@ -82,13 +82,8 @@ public class ResourceFinder {
 
         ResourceResponse response = null;
         Boolean isLegacyProject = Utils.isLegacyProject(uri);
-        try {
-            String projectRootPath = Utils.findProjectRootPath(uri, isLegacyProject);
-            if (projectRootPath != null) {
-                response = findResources(projectRootPath, resourceType, isLegacyProject);
-            }
-        } catch (IOException e) {
-            LOGGER.warning("Error while finding project root path");
+        if (uri != null) {
+            response = findResources(uri, resourceType, isLegacyProject);
         }
         return response;
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/SyntaxTreeGenerator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/SyntaxTreeGenerator.java
@@ -63,7 +63,6 @@ public class SyntaxTreeGenerator {
 
     public SyntaxTreeResponse getSyntaxTree(DOMDocument document) {
 
-        setProjectPath(document.getDocumentURI());
         SyntaxTreeResponse response = new SyntaxTreeResponse(null, document.getDocumentURI());
         DOMElement rootElement = getRootElement(document);
         STNode tree = buildTree(rootElement);
@@ -82,17 +81,9 @@ public class SyntaxTreeGenerator {
         return response;
     }
 
-    private void setProjectPath(String documentURI) {
+    public void setProjectPath(String path) {
 
-        if (documentURI != null) {
-            String tempUri = documentURI.replace(Constant.FILE_PREFIX, Constant.EMPTY_STRING);
-            Boolean isLegacy = Utils.isLegacyProject(tempUri);
-            try {
-                projectPath = Utils.findProjectRootPath(tempUri, isLegacy);
-            } catch (IOException e) {
-                LOGGER.log(Level.SEVERE, "Error occurred while finding the project root path.", e);
-            }
-        }
+        projectPath = path;
     }
 
     private DOMElement getRootElement(DOMDocument document) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -120,82 +120,30 @@ public class Utils {
         return list.stream().anyMatch(s -> s.equalsIgnoreCase(elementName));
     }
 
-    public static boolean isLegacyProject(DOMDocument document) {
-
-        String documentPath = document.getDocumentURI();
-        return isLegacyProject(documentPath);
-    }
-
     public static boolean isLegacyProject(String path) {
-        String projectPath = null;
-        try {
-            projectPath = findLegacyProjectRootPath(path);
-        } catch (IOException e) {
-        }
 
-        if(projectPath != null) {
-            return Boolean.TRUE;
-        }
-        return Boolean.FALSE;
-    }
-
-    public static String findProjectRootPath(String currentPath,boolean isLegacyProject) throws IOException {
-        if(isLegacyProject) {
-            return findLegacyProjectRootPath(currentPath);
-        } else {
-            return findProjectRootPath(currentPath);
-        }
-    }
-
-    public static String findLegacyProjectRootPath(String currentPath) throws IOException {
-
-        if (currentPath.contains(Constant.FILE_PREFIX)) {
-            currentPath = currentPath.substring(7);
-        }
-        if (currentPath == null || currentPath.isEmpty()) {
-            return null;
-        }
-        String prevFolderPath = currentPath.substring(0, currentPath.lastIndexOf(File.separator));
-        String dotProjectPath = currentPath + File.separator + Constant.DOT_PROJECT;
+        String dotProjectPath = path + File.separator + Constant.DOT_PROJECT;
         File dotProjectFile = new File(dotProjectPath);
         if (dotProjectFile != null && dotProjectFile.exists()) {
-            DOMDocument projectDOM = Utils.getDOMDocument(dotProjectFile);
-            DOMNode descriptionNode = findDescriptionNode(projectDOM);
-            if (descriptionNode != null) {
-                DOMNode naturesNode = findNaturesNode(descriptionNode);
-                if (naturesNode != null) {
-                    List<DOMNode> children = naturesNode.getChildren();
-                    for (DOMNode child : children) {
-                        String nature = Utils.getInlineString(child.getFirstChild());
-                        if (ProjectType.ROOT_PROJECT.value.equalsIgnoreCase(nature)) {
-                            return currentPath;
+            try {
+                DOMDocument projectDOM = Utils.getDOMDocument(dotProjectFile);
+                DOMNode descriptionNode = findDescriptionNode(projectDOM);
+                if (descriptionNode != null) {
+                    DOMNode naturesNode = findNaturesNode(descriptionNode);
+                    if (naturesNode != null) {
+                        List<DOMNode> children = naturesNode.getChildren();
+                        for (DOMNode child : children) {
+                            String nature = Utils.getInlineString(child.getFirstChild());
+                            if (ProjectType.ROOT_PROJECT.value.equalsIgnoreCase(nature)) {
+                                return Boolean.TRUE;
+                            }
                         }
                     }
-                    return findLegacyProjectRootPath(prevFolderPath);
                 }
+            } catch (IOException e) {
             }
-        } else {
-            return findLegacyProjectRootPath(prevFolderPath);
         }
-        return null;
-    }
-
-    public static String findProjectRootPath(String currentPath) {
-
-        if (currentPath.contains(Constant.FILE_PREFIX)) {
-            currentPath = currentPath.substring(7);
-        }
-        if (currentPath == null || currentPath.isEmpty()) {
-            return null;
-        }
-        String prevFolderPath = currentPath.substring(0, currentPath.lastIndexOf(File.separator));
-        String pomPath = currentPath + File.separator + Constant.POM;
-        File pomFile = new File(pomPath);
-        if (pomFile != null && pomFile.exists()) {
-            return currentPath;
-        } else {
-            return findProjectRootPath(prevFolderPath);
-        }
+        return Boolean.FALSE;
     }
 
     public static DOMNode findDescriptionNode(DOMDocument projectDOM) {


### PR DESCRIPTION
The project root uri is now available in the SynapseLanguageService class. So we can get rid of the project root finding logic.