### PR TITLE
Add registry type to getAvailableResource method

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/ResourceFinder.java
@@ -314,15 +314,12 @@ public class ResourceFinder {
 
         Resource registry = new RegistryResource();
         String name = getArtifactName(rootElement);
-        if (name != null) {
-            registry.setName(name);
-            registry.setType(Utils.addUnderscoreBetweenWords(type).toUpperCase());
-            registry.setFrom(REGISTRY);
-            ((RegistryResource) registry).setRegistryPath(file.getAbsolutePath());
-            ((RegistryResource) registry).setRegistryKey(getRegistryKey(file));
-            return registry;
-        }
-        return null;
+        registry.setName(name);
+        registry.setType(Utils.addUnderscoreBetweenWords(type).toUpperCase());
+        registry.setFrom(REGISTRY);
+        ((RegistryResource) registry).setRegistryPath(file.getAbsolutePath());
+        ((RegistryResource) registry).setRegistryKey(getRegistryKey(file));
+        return registry;
     }
 
     private static String getArtifactName(DOMElement rootElement) {


### PR DESCRIPTION
This PR adds "registry" resource type to the getAvailableResource method. This will return all the available registry resources in the project regardless of its type.