### PR TITLE
Extract connectors from connector exporters

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/AbstractConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/AbstractConnectorLoader.java
@@ -42,6 +42,7 @@ public abstract class AbstractConnectorLoader {
     private SynapseLanguageClientAPI languageClient;
     protected ConnectorHolder connectorHolder;
     private ConnectorReader connectorReader;
+    protected String projectUri;
     protected String connectorsZipFolderPath;
     private File connectorExtractFolder;
 
@@ -54,6 +55,7 @@ public abstract class AbstractConnectorLoader {
 
     public void init(String projectRoot) {
 
+        this.projectUri = projectRoot;
         setConnectorsZipFolderPath(projectRoot);
         connectorExtractFolder = getConnectorExtractFolder();
     }
@@ -74,7 +76,7 @@ public abstract class AbstractConnectorLoader {
 
     protected abstract boolean canContinue(File connectorExtractFolder);
 
-    private List<File> getConnectorZips() {
+    protected List<File> getConnectorZips() {
 
         List<File> connectorZips = new ArrayList<>();
         File folder = new File(connectorsZipFolderPath);


### PR DESCRIPTION
When the LS starts it will read the project and if it is an old project, it will get all the connectors inside the connector exporters projects and extract it to the connector extraction folder.