### PR TITLE
Fix NPE while getting inline xml

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -50,7 +50,7 @@ public class Utils {
 
     public static String getInlineString(DOMNode node) {
 
-        String inline = null;
+        String inline = "";
         if (node != null) {
             if (node.isCDATA()) {
                 inline = "<![CDATA[" + node.getTextContent() + "]]>";
@@ -59,7 +59,7 @@ public class Utils {
             } else if (node instanceof DOMElement) {
                 if (((DOMElement) node).isSelfClosed()) {
                     inline = "<" + node.getNodeName().concat(getAttributeXmlString(node)) + "/>";
-                } else {
+                } else if (!((DOMElement) node).isOrphanEndTag()) {
                     inline = "<" + node.getNodeName().concat(getAttributeXmlString(node)) + ">";
                     List<DOMNode> children = node.getChildren();
                     if (children != null && !children.isEmpty()) {


### PR DESCRIPTION
The `getInlineString` method is throwing NPE when reading an orphan end tag. This PR fixes this issue.