### PR TITLE
Add syntax tree support for mock service

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/SyntaxTreeGenerator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/SyntaxTreeGenerator.java
@@ -34,7 +34,8 @@ import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.NamedSequenc
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.ProxyFactory;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.TaskFactory;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.TemplateFactory;
-import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.UnitTestFactory;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.test.MockServiceFactory;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.test.UnitTestFactory;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.endpoint.EndpointFactory;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.misc.Wsdl11Factory;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.misc.Wsdl20Factory;
@@ -46,11 +47,9 @@ import org.eclipse.lemminx.customservice.synapse.utils.Utils;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SyntaxTreeGenerator {
@@ -61,7 +60,7 @@ public class SyntaxTreeGenerator {
     private static List<String> componentNames = Arrays.asList(Constant.API, Constant.ENDPOINT, Constant.INBOUND_ENDPOINT,
             Constant.MESSAGE_PROCESSOR, Constant.LOCAL_ENTRY, Constant.MESSAGE_STORE, Constant.PROXY, Constant.SEQUENCE,
             Constant.TASK, Constant.TEMPLATE, Constant.WSDL_DEFINITIONS, Constant.WSDL_DESCRIPTION, Constant.DATA,
-            Constant.DATA_SOURCE, Constant.UNIT_TEST);
+            Constant.DATA_SOURCE, Constant.UNIT_TEST, Constant.MOCK_SERVICE);
 
     public SyntaxTreeResponse getSyntaxTree(DOMDocument document) {
 
@@ -136,6 +135,8 @@ public class SyntaxTreeGenerator {
                 factory = new DataSourceConfigFactory();
             } else if (Constant.UNIT_TEST.equalsIgnoreCase(xmlNode.getNodeName())) {
                 factory = new UnitTestFactory();
+            } else if (Constant.MOCK_SERVICE.equalsIgnoreCase(xmlNode.getNodeName())) {
+                factory = new MockServiceFactory();
             }
         }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/test/MockServiceFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/test/MockServiceFactory.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.test;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.AbstractFactory;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice.Header;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice.Headers;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice.MockService;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice.MockServiceResource;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice.MockServiceResourceRequest;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice.MockServiceResourceResponse;
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice.MockServiceResources;
+import org.eclipse.lemminx.customservice.synapse.utils.Constant;
+import org.eclipse.lemminx.customservice.synapse.utils.Utils;
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMNode;
+
+import java.util.List;
+
+public class MockServiceFactory extends AbstractFactory {
+
+    @Override
+    public STNode create(DOMElement element) {
+
+        MockService mockService = new MockService();
+        mockService.elementNode(element);
+
+        List<DOMNode> children = element.getChildren();
+
+        if (children != null) {
+            for (DOMNode child : children) {
+                String childName = child.getNodeName();
+                if (Constant.MOCK_SERVICE_NAME.equalsIgnoreCase(childName)) {
+                    STNode serviceName = createSimpleNode((DOMElement) child);
+                    mockService.setServiceName(serviceName);
+                } else if (Constant.PORT.equalsIgnoreCase(childName)) {
+                    STNode port = createSimpleNode((DOMElement) child);
+                    mockService.setPort(port);
+                } else if (Constant.CONTEXT.equalsIgnoreCase(childName)) {
+                    STNode context = createSimpleNode((DOMElement) child);
+                    mockService.setContext(context);
+                } else if (Constant.RESOURCES.equalsIgnoreCase(childName)) {
+                    MockServiceResources resources = createMockServiceResources((DOMElement) child);
+                    mockService.setResources(resources);
+                }
+            }
+        }
+        return mockService;
+    }
+
+    private MockServiceResources createMockServiceResources(DOMElement node) {
+
+        MockServiceResources resources = new MockServiceResources();
+        resources.elementNode(node);
+
+        List<DOMNode> children = node.getChildren();
+        if (children != null) {
+            for (DOMNode child : children) {
+                String childName = child.getNodeName();
+                if (Constant.RESOURCE.equalsIgnoreCase(childName)) {
+                    MockServiceResource resource = createMockServiceResource((DOMElement) child);
+                    resources.addResource(resource);
+                }
+            }
+        }
+        return resources;
+    }
+
+    private MockServiceResource createMockServiceResource(DOMElement node) {
+
+        MockServiceResource resource = new MockServiceResource();
+        resource.elementNode(node);
+
+        List<DOMNode> children = node.getChildren();
+        if (children != null) {
+            for (DOMNode child : children) {
+                String childName = child.getNodeName();
+                if (Constant.SUB_CONTEXT.equalsIgnoreCase(childName)) {
+                    STNode subContext = createSimpleNode((DOMElement) child);
+                    resource.setSubContext(subContext);
+                } else if (Constant.METHOD.equalsIgnoreCase(childName)) {
+                    STNode method = createSimpleNode((DOMElement) child);
+                    resource.setMethod(method);
+                } else if (Constant.REQUEST.equalsIgnoreCase(childName)) {
+                    MockServiceResourceRequest request = createMockServiceResourceRequest((DOMElement) child);
+                    resource.setRequest(request);
+                } else if (Constant.RESPONSE.equalsIgnoreCase(childName)) {
+                    MockServiceResourceResponse response = createMockServiceResourceResponse((DOMElement) child);
+                    resource.setResponse(response);
+                }
+            }
+        }
+        return resource;
+    }
+
+    private MockServiceResourceRequest createMockServiceResourceRequest(DOMElement node) {
+
+        MockServiceResourceRequest request = new MockServiceResourceRequest();
+        request.elementNode(node);
+
+        List<DOMNode> children = node.getChildren();
+        if (children != null) {
+            for (DOMNode child : children) {
+                String childName = child.getNodeName();
+                if (Constant.PAYLOAD.equalsIgnoreCase(childName)) {
+                    STNode payload = createSimpleNode((DOMElement) child);
+                    request.setPayload(payload);
+                } else if (Constant.HEADERS.equalsIgnoreCase(childName)) {
+                    Headers headers = createHeaders((DOMElement) child);
+                    request.setHeaders(headers);
+                }
+            }
+        }
+        return request;
+    }
+
+    private MockServiceResourceResponse createMockServiceResourceResponse(DOMElement node) {
+
+        MockServiceResourceResponse response = new MockServiceResourceResponse();
+        response.elementNode(node);
+
+        List<DOMNode> children = node.getChildren();
+        if (children != null) {
+            for (DOMNode child : children) {
+                String childName = child.getNodeName();
+                if (Constant.STATUS_CODE.equalsIgnoreCase(childName)) {
+                    STNode statusCode = createSimpleNode((DOMElement) child);
+                    response.setStatusCode(statusCode);
+                } else if (Constant.PAYLOAD.equalsIgnoreCase(childName)) {
+                    STNode payload = createSimpleNode((DOMElement) child);
+                    response.setPayload(payload);
+                } else if (Constant.HEADERS.equalsIgnoreCase(childName)) {
+                    Headers headers = createHeaders((DOMElement) child);
+                    response.setHeaders(headers);
+                }
+            }
+        }
+        return response;
+    }
+
+    private Headers createHeaders(DOMElement node) {
+
+        Headers headers = new Headers();
+        headers.elementNode(node);
+
+        List<DOMNode> children = node.getChildren();
+        if (children != null) {
+            for (DOMNode child : children) {
+                String childName = child.getNodeName();
+                if (Constant.HEADER.equalsIgnoreCase(childName)) {
+                    Header header = createHeader((DOMElement) child);
+                    headers.addHeader(header);
+                }
+            }
+        }
+        return headers;
+    }
+
+    private Header createHeader(DOMElement node) {
+
+        Header header = new Header();
+        header.elementNode(node);
+
+        String name = node.getAttribute(Constant.NAME);
+        if (name != null) {
+            header.setName(name);
+        }
+        String value = node.getAttribute(Constant.VALUE);
+        if (value != null) {
+            header.setValue(value);
+        }
+
+        return header;
+    }
+
+    private STNode createSimpleNode(DOMElement element) {
+
+        STNode node = new STNode();
+        node.elementNode(element);
+        String content = Utils.getInlineString(element.getFirstChild());
+        node.setTextNode(content);
+        return node;
+    }
+
+    @Override
+    public void populateAttributes(STNode node, DOMElement element) {
+
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/test/UnitTestFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/test/UnitTestFactory.java
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-package org.eclipse.lemminx.customservice.synapse.syntaxTree.factory;
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.test;
 
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.AbstractFactory;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.Artifact;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.AssertEquals;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/Header.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/Header.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+
+public class Header extends STNode {
+
+    String name;
+    String value;
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getValue() {
+
+        return value;
+    }
+
+    public void setValue(String value) {
+
+        this.value = value;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/Headers.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/Headers.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Headers extends STNode {
+
+    List<Header> headers;
+
+    public Headers() {
+
+        this.headers = new ArrayList<>();
+    }
+
+    public List<Header> getHeaders() {
+
+        return headers;
+    }
+
+    public void setHeaders(List<Header> headers) {
+
+        this.headers = headers;
+    }
+
+    public void addHeader(Header header) {
+
+        headers.add(header);
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+
+public class MockService extends STNode {
+
+    STNode serviceName;
+    STNode port;
+    STNode context;
+    MockServiceResources resources;
+
+    public STNode getServiceName() {
+
+        return serviceName;
+    }
+
+    public void setServiceName(STNode serviceName) {
+
+        this.serviceName = serviceName;
+    }
+
+    public STNode getPort() {
+
+        return port;
+    }
+
+    public void setPort(STNode port) {
+
+        this.port = port;
+    }
+
+    public STNode getContext() {
+
+        return context;
+    }
+
+    public void setContext(STNode context) {
+
+        this.context = context;
+    }
+
+    public MockServiceResources getResources() {
+
+        return resources;
+    }
+
+    public void setResources(MockServiceResources resources) {
+
+        this.resources = resources;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockServiceResource.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockServiceResource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+
+public class MockServiceResource extends STNode {
+
+    STNode subContext;
+    STNode method;
+    MockServiceResourceRequest request;
+    MockServiceResourceResponse response;
+
+    public STNode getSubContext() {
+
+        return subContext;
+    }
+
+    public void setSubContext(STNode subContext) {
+
+        this.subContext = subContext;
+    }
+
+    public STNode getMethod() {
+
+        return method;
+    }
+
+    public void setMethod(STNode method) {
+
+        this.method = method;
+    }
+
+    public MockServiceResourceRequest getRequest() {
+
+        return request;
+    }
+
+    public void setRequest(MockServiceResourceRequest request) {
+
+        this.request = request;
+    }
+
+    public MockServiceResourceResponse getResponse() {
+
+        return response;
+    }
+
+    public void setResponse(MockServiceResourceResponse response) {
+
+        this.response = response;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockServiceResourceRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockServiceResourceRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+
+public class MockServiceResourceRequest extends STNode {
+
+    Headers headers;
+    STNode payload;
+
+    public Headers getHeaders() {
+
+        return headers;
+    }
+
+    public void setHeaders(Headers headers) {
+
+        this.headers = headers;
+    }
+
+    public STNode getPayload() {
+
+        return payload;
+    }
+
+    public void setPayload(STNode payload) {
+
+        this.payload = payload;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockServiceResourceResponse.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockServiceResourceResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+
+public class MockServiceResourceResponse extends STNode {
+
+    STNode statusCode;
+    STNode payload;
+    Headers headers;
+
+    public STNode getStatusCode() {
+
+        return statusCode;
+    }
+
+    public void setStatusCode(STNode statusCode) {
+
+        this.statusCode = statusCode;
+    }
+
+    public STNode getPayload() {
+
+        return payload;
+    }
+
+    public void setPayload(STNode payload) {
+
+        this.payload = payload;
+    }
+
+    public Headers getHeaders() {
+
+        return headers;
+    }
+
+    public void setHeaders(Headers headers) {
+
+        this.headers = headers;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockServiceResources.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/test/mockservice/MockServiceResources.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.test.mockservice;
+
+import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockServiceResources extends STNode {
+
+    List<MockServiceResource> resources;
+
+    public MockServiceResources() {
+
+        this.resources = new ArrayList<>();
+    }
+
+    public List<MockServiceResource> getResources() {
+
+        return resources;
+    }
+
+    public void setResources(List<MockServiceResource> resources) {
+
+        this.resources = resources;
+    }
+
+    public void addResource(MockServiceResource resource) {
+
+        resources.add(resource);
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -466,4 +466,10 @@ public class Constant {
     public static final String FILE_NAME = "file-name";
     public static final String ARTIFACT = "artifact";
     public static final String REGISTRY_PATH = "registry-path";
+    public static final String MOCK_SERVICE_NAME = "service-name";
+    public static final String RESOURCES = "resources";
+    public static final String SUB_CONTEXT = "sub-context";
+    public static final String HEADERS = "headers";
+    public static final String STATUS_CODE = "status-code";
+    public static final String HEADER = "header";
 }


### PR DESCRIPTION
This commit add syntax tree support for mock services that are used in unit tests.