### PR TITLE
Add support to get available resources from local entry

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
@@ -78,7 +78,6 @@ public abstract class AbstractResourceFinder {
         typeToXmlTagMap.put("xslt", "xsl:stylesheet");
         typeToXmlTagMap.put("xsd", "xs:schema");
         typeToXmlTagMap.put("wsdl", "wsdl:definitions");
-        typeToXmlTagMap.put("ws_policy", "wsp:Policy");
     }
 
     public ResourceResponse getAvailableResources(String uri, Either<String, List<RequestedResource>> resourceTypes) {


### PR DESCRIPTION
Currently the getAvailabelResources method doesn't get resources in local entry other than main artifacts. This PR
adds support to get those resources also as the response.

Fixes: https://github.com/wso2/mi-vscode/issues/265