### PR TITLE
Fix StringIndexOutOfBoundException for invalid xml

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/STNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/STNode.java
@@ -83,7 +83,9 @@ public class STNode {
         Range endTagRange = createRange(endTagOpenPosition, endTagClosePosition);
         TagRanges range = new TagRanges(startTagRange, endTagRange);
 
-        calculateLeadingAndTrailingSpaces(node, range);
+        if (!node.isOrphanEndTag()) {
+            calculateLeadingAndTrailingSpaces(node, range);
+        }
         return range;
     }
 


### PR DESCRIPTION
When a user manually edits the XML, there may be instances where the XML becomes temporarily invalid. For example, if there is an orphan end tag in the XML, it becomes impossible to calculate leading and trailing spaces as we don't have the range of starting tag. This PR fixes this issue by ignoring the calculation of leading and trailing spaces for orphan end tag.

Fixes: https://github.com/wso2/mi-vscode/issues/361