### PR TITLE
Fix unit test syntax tree

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.eclipse.lemminx</groupId>
 		<artifactId>lemminx-parent</artifactId>
-		<version>0.24.0-wso2v31-SNAPSHOT</version>
+		<version>0.24.0-wso2v32-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>org.eclipse.lemminx</artifactId>

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/test/UnitTestFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/test/UnitTestFactory.java
@@ -200,15 +200,15 @@ public class UnitTestFactory extends AbstractFactory {
         return registryResource;
     }
 
-    private TestConnectorResources createTestConnectorResources(DOMElement child) {
+    private TestConnectorResources createTestConnectorResources(DOMElement node) {
 
         TestConnectorResources connectorResources = new TestConnectorResources();
-        connectorResources.elementNode(child);
+        connectorResources.elementNode(node);
 
-        List<DOMNode> children = child.getChildren();
+        List<DOMNode> children = node.getChildren();
         if (children != null && !children.isEmpty()) {
             List<STNode> connectorResourceList = new ArrayList<>();
-            for (DOMNode node : children) {
+            for (DOMNode child : children) {
                 STNode connectorResource = createSimpleNode((DOMElement) child);
                 connectorResourceList.add(connectorResource);
             }
@@ -302,8 +302,10 @@ public class UnitTestFactory extends AbstractFactory {
         List<DOMNode> children = node.getChildren();
         if (children != null && !children.isEmpty()) {
             for (DOMNode child : children) {
-                TestProperty property = createTestProperty((DOMElement) child);
-                testProperties.addProperty(property);
+                if (child instanceof DOMElement) {
+                    TestProperty property = createTestProperty((DOMElement) child);
+                    testProperties.addProperty(property);
+                }
             }
         }
         return testProperties;

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.lemminx</groupId>
 	<artifactId>lemminx-parent</artifactId>
-	<version>0.24.0-wso2v31-SNAPSHOT</version>
+	<version>0.24.0-wso2v32-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Eclipse LemMinX</name>
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>


### PR DESCRIPTION
The syntax tree generator is failing when we provide a unit test xml with `<properties>` tag that doesn't have any child properties. This PR fixes this issue.