### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   


### PR DESCRIPTION
This PR disables dependabot. This will be enabled once the test cases are written for all the features.