### PR TITLE
Use XML escaping in mustaches

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/SynapseMustacheFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/SynapseMustacheFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.utils;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.MustacheException;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class SynapseMustacheFactory extends DefaultMustacheFactory {
+
+    @Override
+    public void encode(String value, Writer writer) {
+
+        String escapedValue = Utils.escapeXML(value);
+        try {
+            writer.write(escapedValue);
+        } catch (IOException e) {
+            throw new MustacheException("Failed to write encode value: " + value);
+        }
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -19,7 +19,6 @@
 package org.eclipse.lemminx.customservice.synapse.utils;
 
 import com.github.fge.jackson.JsonLoader;
-import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.google.gson.Gson;
@@ -86,6 +85,7 @@ public class Utils {
 
     private static final Logger logger = Logger.getLogger(Utils.class.getName());
     private static FileSystem fileSystem;
+    private static final MustacheFactory mustacheFactory = new SynapseMustacheFactory();
 
     /**
      * Get the inline string of the given node
@@ -558,6 +558,18 @@ public class Utils {
                 .replace("&quot;", "\"");
     }
 
+    public static String escapeXML(String text) {
+
+        if (text == null) {
+            return null;
+        }
+        return text
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;");
+    }
+
     public static String removeFilePrefix(String artifactPath) {
 
         if (artifactPath.contains(Constant.FILE_PREFIX)) {
@@ -687,7 +699,6 @@ public class Utils {
 
     private static void loadTemplate(Path path, String resourceFolder, Map<String, Mustache> templateMap) {
         String templateName = path.getFileName().toString().replace(".mustache", "");
-        MustacheFactory mustacheFactory = new DefaultMustacheFactory();
         try (InputStreamReader reader = new InputStreamReader(
                 Utils.class.getClassLoader().getResourceAsStream(resourceFolder + "/" + path.getFileName()))) {
             Mustache template = mustacheFactory.compile(reader, templateName);


### PR DESCRIPTION
## Purpose

By default `DefaultMustacheFactory` use HTML escaping. Therefore override the `encode` method to use XML escaping,