### PR TITLE
Support invalid operation name in connector ui schema

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -565,6 +565,22 @@ public class Utils {
     }
 
     /**
+     * Get the file name without the extension
+     *
+     * @param file
+     * @return
+     */
+    public static String getFileName(File file) {
+
+        String fileName = file.getName();
+        int dotIndex = fileName.lastIndexOf(".");
+        if (dotIndex != -1) {
+            return fileName.substring(0, dotIndex);
+        }
+        return fileName;
+    }
+
+    /**
      * Unescape the given XML text
      *
      * @param text


### PR DESCRIPTION
There are some connector ui schemas that have invalid operation name (Eg: Email connector - markAsDeleted operation). This PR modifies the LS to support invalid operation name in the UI schema.