### PR TITLE
Update variable mediator OM data type to XML

### DIFF
--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/variable.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/variable.json
@@ -40,13 +40,11 @@
         "defaultValue": "STRING",
         "comboValues": [
           "STRING",
-          "INTEGER",
           "BOOLEAN",
-          "DOUBLE",
-          "FLOAT",
+          "INTEGER",
           "LONG",
-          "SHORT",
-          "OM",
+          "DOUBLE",
+          "XML",
           "JSON"
         ],
         "required": true,

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/schemas/440/mediators/core/variable.xsd
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/schemas/440/mediators/core/variable.xsd
@@ -43,10 +43,8 @@
                         <xs:enumeration value="INTEGER"/>
                         <xs:enumeration value="BOOLEAN"/>
                         <xs:enumeration value="DOUBLE"/>
-                        <xs:enumeration value="FLOAT"/>
                         <xs:enumeration value="LONG"/>
-                        <xs:enumeration value="SHORT"/>
-                        <xs:enumeration value="OM"/>
+                        <xs:enumeration value="XML"/>
                         <xs:enumeration value="JSON"/>
                     </xs:restriction>
                 </xs:simpleType>


### PR DESCRIPTION
## Purpose
1. Update variable mediator data types to the following,

`STRING, BOOLEAN, INTEGER, LONG, DOUBLE, JSON, XML`

2. Rename OM to XML

Fixes: https://github.com/wso2/mi-vscode/issues/586