### PR TITLE
Improve CAPP building for the tryout feature

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediator/tryout/TryOutHandler.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediator/tryout/TryOutHandler.java
@@ -94,7 +94,7 @@ public class TryOutHandler {
 
         this.projectUri = projectUri;
         this.lock = new Object();
-        server = new MIServer(Path.of(miServerPath));
+        server = new MIServer(Path.of(miServerPath), projectUri);
         activeBreakpoints = new ArrayList<>();
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediator/tryout/TryOutManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediator/tryout/TryOutManager.java
@@ -63,6 +63,7 @@ public class TryOutManager {
     public boolean shutdown() {
 
         tryOutHandler.reset();
+        CAPPCacheManager.shutdown();
         return tryOutHandler.shutDown();
     }
 }


### PR DESCRIPTION
This PR:
1. Improves the build time for CAPP in tryout feature by:
   - Separating CAPPs into: connector, class mediator, resources, datamapper
   - Each CAPP rebuilds only if there are changes in its respective files
2. Adds environment variables support in tryout feature