### PR TITLE
Add UI schema generation for old connectors

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/ConnectionTester.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/ConnectionTester.java
@@ -20,6 +20,7 @@ package org.eclipse.lemminx.customservice.synapse.connectors;
 
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.ConnectorAction;
+import org.eclipse.lemminx.customservice.synapse.connectors.entity.OperationParameter;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.TestConnectionRequest;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.TestConnectionResponse;
 import org.eclipse.lemminx.customservice.synapse.mediator.TryOutConstants;
@@ -178,10 +179,10 @@ public class ConnectionTester {
         connection.setTag(initOperation.getTag());
         connection.setMethod(Constant.INIT);
         if (parameters != null) {
-            for (String parameter : initOperation.getParameters()) {
+            for (OperationParameter parameter : initOperation.getParameters()) {
                 if (parameters.containsKey(parameter)) {
                     ConnectorParameter connectorParameter = new ConnectorParameter();
-                    connectorParameter.setName(parameter);
+                    connectorParameter.setName(parameter.getName());
                     if (parameters.get(parameter) instanceof Map) {
                         Map parameterMap = (Map) parameters.get(parameter);
                         if (Boolean.parseBoolean(parameterMap.get(Constant.IS_EXPRESSION).toString())) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/SchemaGenerate.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/SchemaGenerate.java
@@ -20,6 +20,7 @@ package org.eclipse.lemminx.customservice.synapse.connectors;
 
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.ConnectorAction;
+import org.eclipse.lemminx.customservice.synapse.connectors.entity.OperationParameter;
 
 import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
@@ -98,9 +99,9 @@ public class SchemaGenerate {
                     sb.append("            <xs:element name=\"" + action.getTag() + "\">\n");
                     sb.append("                <xs:complexType>\n" +
                             "                    <xs:all>\n");
-                    for (String parameter : action.getParameters()) {
-                        sb.append("                        <xs:element name=\"" + parameter + "\" type=\"xs:string\" " +
-                                "minOccurs=\"0\" maxOccurs=\"1\" />\n");
+                    for (OperationParameter parameter : action.getParameters()) {
+                        sb.append("                        <xs:element name=\"" + parameter.getName() +
+                                "\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"1\" />\n");
                     }
                     sb.append("                    </xs:all>\n");
                     sb.append("                    <xs:attribute name=\"configKey\" type=\"xs:string\"/>\n");

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/entity/ConnectorAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/entity/ConnectorAction.java
@@ -37,7 +37,7 @@ public class ConnectorAction {
     private String name;
     private String tag;
     private String displayName;
-    private List<String> parameters;
+    private List<OperationParameter> parameters;
     private List<String> allowedConnectionTypes;
     private String description;
     private Boolean isHidden;
@@ -81,17 +81,17 @@ public class ConnectorAction {
         this.tag = tag;
     }
 
-    public void addParameter(String parameter) {
+    public void addParameter(OperationParameter parameter) {
 
         parameters.add(parameter);
     }
 
-    public List<String> getParameters() {
+    public List<OperationParameter> getParameters() {
 
         return Collections.unmodifiableList(parameters);
     }
 
-    public void setParameters(List<String> parameters) {
+    public void setParameters(List<OperationParameter> parameters) {
 
         this.parameters = parameters;
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/entity/OperationParameter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/entity/OperationParameter.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.eclipse.lemminx.customservice.synapse.connectors.entity;
+
+public class OperationParameter {
+
+    private String name;
+    private String description;
+
+    public OperationParameter(String name, String description) {
+
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/MediatorHandler.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/MediatorHandler.java
@@ -27,6 +27,7 @@ import com.google.gson.internal.LinkedTreeMap;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.ConnectorAction;
+import org.eclipse.lemminx.customservice.synapse.connectors.entity.OperationParameter;
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.SynapseConfigResponse;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.factory.mediators.MediatorFactoryFinder;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.STNode;
@@ -141,15 +142,15 @@ public class MediatorHandler {
 
         ConnectorAction operation = getConnectorOperation(node, mediator);
         if (operation != null) {
-            List<String> parameters = operation.getParameters();
+            List<OperationParameter> parameters = operation.getParameters();
             Map<String, Object> connectorData = new HashMap<>();
             connectorData.put(Constant.TAG, operation.getTag());
             connectorData.put(Constant.CONFIG_KEY, data.get(Constant.CONFIG_KEY));
             List<Object> parameterData = new ArrayList<>();
-            for (String parameter : parameters) {
-                if (data.containsKey(parameter)) {
-                    Map<String, Object> dataValue = processConnectorParameter(data.get(parameter));
-                    parameterData.add(Map.of(Constant.NAME, parameter, Constant.VALUE, dataValue));
+            for (OperationParameter parameter : parameters) {
+                if (data.containsKey(parameter.getName())) {
+                    Map<String, Object> dataValue = processConnectorParameter(data.get(parameter.getName()));
+                    parameterData.add(Map.of(Constant.NAME, parameter.getName(), Constant.VALUE, dataValue));
                 }
             }
             connectorData.put(Constant.PARAMETERS, parameterData);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -545,4 +545,8 @@ public class Constant {
     public static final String ITEMS = "items";
     public static final String FAVOURITES = "favourites";
     public static final String ARTIFACT_ID = "artifactId";
+    public static final String CONNECTOR_NAME = "connectorName";
+    public static final String HELP = "help";
+    public static final String REQUIRED = "required";
+    public static final String HELP_TIP = "helpTip";
 }


### PR DESCRIPTION
Some connectors are not having the ui schema for the operations. This commit adds the ui schema generation for these connectors.