### PR TITLE
Fix connector flow for older car plugin versions

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/AbstractConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/AbstractConnectorLoader.java
@@ -69,10 +69,13 @@ public abstract class AbstractConnectorLoader {
             List<File> connectorZips = getConnectorZips();
             connectorHolder.setConnectorZips(Collections.unmodifiableList(connectorZips));
             cleanOldConnectors(connectorExtractFolder, connectorZips);
+            copyToProjectIfNeeded(connectorZips);
             extractZips(connectorZips, connectorExtractFolder);
             readConnectors(connectorExtractFolder);
         }
     }
+
+    protected abstract void copyToProjectIfNeeded(List<File> connectorZips);
 
     protected abstract File getConnectorExtractFolder();
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/OldProjectConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/OldProjectConnectorLoader.java
@@ -37,6 +37,11 @@ public class OldProjectConnectorLoader extends AbstractConnectorLoader {
     }
 
     @Override
+    protected void copyToProjectIfNeeded(List<File> connectorZips) {
+        // Do nothing
+    }
+
+    @Override
     protected File getConnectorExtractFolder() {
 
         File connectorsFolderPath = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/Constants.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/Constants.java
@@ -65,6 +65,7 @@ public class Constants {
     public static final String KEY_STORE_NAME = "keystore.name";
     public static final String KEY_STORE_TYPE = "keystore.type";
     public static final String PROJECT_RUNTIME_VERSION = "project.runtime.version";
+    public static final String CAR_PLUGIN_VERSION = "car.plugin.version";
     public static final String DOCKER_MAVEN_PLUGIN = "docker-maven-plugin";
     public static final String HASH = "#";
     public static final String COLON = ":";

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/PluginDetails.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/PluginDetails.java
@@ -45,4 +45,9 @@ public class PluginDetails {
         ranges.add(range);
         this.projectBuildPluginVersion = new Node(pluginVersion, Either.forRight(ranges));
     }
+
+    public Node getProjectBuildPluginVersion() {
+
+        return projectBuildPluginVersion;
+    }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/pom/PluginHandler.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/pom/PluginHandler.java
@@ -250,6 +250,10 @@ public class PluginHandler extends DefaultHandler {
                 pomDetailsResponse.getBuildDetails().getDockerDetails().setDockerFileBaseImage(
                         new Node(value, Either.forLeft(range)));
                 break;
+            case Constants.CAR_PLUGIN_VERSION:
+                pomDetailsResponse.getBuildDetails().getAdvanceDetails().getPluginDetails()
+                        .setProjectBuildPluginVersion(value, range);
+                break;
             case Constants.PROPERTIES:
                 isProperties = false;
                 break;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -553,4 +553,5 @@ public class Constant {
     public static final String TARGET_VARIABLE = "target-variable";
     public static final String RESULT_CONTENT_TYPE = "result-content-type";
     public static final String RESULT_ENCLOSING_ELEMENT = "result-enclosing-element";
+    public static final String CAR_PLUGIN_CHECK_VERSION = "5.2.88";
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -35,6 +35,8 @@ import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.ConnectorAction;
 import org.eclipse.lemminx.customservice.synapse.directoryTree.legacyBuilder.utils.ProjectType;
+import org.eclipse.lemminx.customservice.synapse.parser.OverviewPageDetailsResponse;
+import org.eclipse.lemminx.customservice.synapse.parser.pom.PomParser;
 import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
@@ -1216,5 +1218,32 @@ public class Utils {
         } catch (Exception e) {
             return StringUtils.EMPTY;
         }
+    }
+
+    /**
+     * Check whether the given project is using an older version of CAR plugin
+     *
+     * @param projectPath
+     * @return
+     */
+    public static boolean isOlderCARPlugin(String projectPath) {
+
+        OverviewPageDetailsResponse overviewPageDetailsResponse = new OverviewPageDetailsResponse();
+        PomParser.getPomDetails(projectPath, overviewPageDetailsResponse);
+        String currentVersion = overviewPageDetailsResponse.getBuildDetails().getAdvanceDetails().getPluginDetails()
+                .getProjectBuildPluginVersion().getValue();
+
+        String[] currentVersionParts = currentVersion.split("\\.");
+        String[] checkVersionParts = Constant.CAR_PLUGIN_CHECK_VERSION.split("\\.");
+        int length = Math.max(currentVersionParts.length, checkVersionParts.length);
+
+        for (int i = 0; i < length; i++) {
+            int v1 = i < checkVersionParts.length ? Integer.parseInt(checkVersionParts[i]) : 0;
+            int v2 = i < currentVersionParts.length ? Integer.parseInt(currentVersionParts[i]) : 0;
+
+            if (v1 < v2) return false;
+            if (v1 > v2) return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
From MI extension version 2.0 onwards, the connector flow has been changed. The connectors will be added to the pom file and resolved while building instead of adding the zip to the project. The user need to use the latest car plugin to support this. This PR fixes the issue for older car plugin versions by adding the connector zip to the project when loading the connector.

Fixes: https://github.com/wso2/mi-vscode/issues/774