### PR TITLE
Add imported connector path for deletion support

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/AbstractConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/AbstractConnectorLoader.java
@@ -136,6 +136,8 @@ public abstract class AbstractConnectorLoader {
             if (!connectorHolder.exists(connectorName)) {
                 Connector connector = connectorReader.readConnector(f.getAbsolutePath());
                 if (connector != null) {
+                    connector.setConnectorZipPath(
+                            getConnectorZip(connectorHolder.getConnectorZips(), connector.getExtractedConnectorPath()));
                     connectorHolder.addConnector(connector);
                     notifyAddConnector(connector.getName(), true, "Connector added successfully");
                     continue;
@@ -144,6 +146,23 @@ public abstract class AbstractConnectorLoader {
                         "Corrupted connector file.");
             }
         }
+    }
+
+    private String getConnectorZip(List<File> connectorZips, String extractedConnectorPath) {
+
+        String extractedConnectorName =
+                extractedConnectorPath.substring(extractedConnectorPath.lastIndexOf(File.separator) + 1);
+        for (File zip : connectorZips) {
+            if (!zip.getAbsolutePath().contains(projectUri)) {
+                continue;
+            }
+            String zipName = zip.getName();
+            zipName = zipName.substring(0, zipName.lastIndexOf("."));
+            if (extractedConnectorName.equals(zipName)) {
+                return zip.getAbsolutePath();
+            }
+        }
+        return null;
     }
 
     protected void notifyAddConnector(String connector, boolean isSuccessful, String message) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/ConnectorReader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/ConnectorReader.java
@@ -66,7 +66,7 @@ public class ConnectorReader {
                         String displayName = Utils.getInlineString(displayNameElement.getFirstChild());
                         connector.setDisplayName(displayName);
                     }
-                    connector.setPath(connectorPath);
+                    connector.setExtractedConnectorPath(connectorPath);
                     setConnectorArtifactIdAndVersion(connector, connectorPath);
                     connector.setIconPath(connectorPath + File.separator + "icon");
                     connector.setUiSchemaPath(connectorPath + File.separator + "uischema");
@@ -188,7 +188,7 @@ public class ConnectorReader {
     private void generateUISchemasIfNeeded(Connector connector) {
 
         for (ConnectorAction action : connector.getActions()) {
-            if (action.getUiSchemaPath() == null) {
+            if (action.getUiSchemaPath() == null && !action.getHidden()) {
                 try {
                     generateUISchema(action, connector);
                 } catch (IOException e) {
@@ -314,8 +314,8 @@ public class ConnectorReader {
     private void readDependencies(Connector connector, List<String> dependencies) {
 
         for (String dependency : dependencies) {
-            File dependencyFile = new File(connector.getPath() + File.separator + dependency + File.separator +
-                    "component.xml");
+            File dependencyFile = Path.of(connector.getExtractedConnectorPath(), dependency, "component.xml")
+                    .toFile();
             if (dependencyFile.exists()) {
                 readSubComponents(connector, dependencyFile);
             }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/entity/Connector.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/entity/Connector.java
@@ -27,7 +27,8 @@ public class Connector {
 
     private String name;
     private String displayName;
-    private String path;
+    private String extractedConnectorPath;
+    private String connectorZipPath;
     private String packageName;
     private String artifactId;
     private String version;
@@ -73,14 +74,24 @@ public class Connector {
         this.packageName = packageName;
     }
 
-    public String getPath() {
+    public String getExtractedConnectorPath() {
 
-        return path;
+        return extractedConnectorPath;
     }
 
-    public void setPath(String path) {
+    public void setExtractedConnectorPath(String extractedConnectorPath) {
 
-        this.path = path;
+        this.extractedConnectorPath = extractedConnectorPath;
+    }
+
+    public String getConnectorZipPath() {
+
+        return connectorZipPath;
+    }
+
+    public void setConnectorZipPath(String connectorZipPath) {
+
+        this.connectorZipPath = connectorZipPath;
     }
 
     public void addAction(ConnectorAction action) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -554,4 +554,5 @@ public class Constant {
     public static final String RESULT_CONTENT_TYPE = "result-content-type";
     public static final String RESULT_ENCLOSING_ELEMENT = "result-enclosing-element";
     public static final String CAR_PLUGIN_CHECK_VERSION = "5.2.88";
+    public static final String CONNECTOR_PATH = "connectorPath";
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -794,6 +794,7 @@ public class Utils {
             connectorObject.addProperty(Constant.IS_CONNECTOR, true);
             connectorObject.addProperty(Constant.ARTIFACT_ID, connector.getArtifactId());
             connectorObject.addProperty(Constant.VERSION, connector.getVersion());
+            connectorObject.addProperty(Constant.CONNECTOR_PATH, connector.getConnectorZipPath());
             mediatorList.add(
                     StringUtils.isEmpty(connector.getDisplayName()) ? connector.getName() : connector.getDisplayName(),
                     connectorObject);


### PR DESCRIPTION
Currently the mediator list is only sending the artifactId and version of the conector to give support to delete it from the project. This will remove the dependecy with the given artifactid and version from the pom. But for imported connectors, there will be no pom entry. So, we need to remove it from the connectors folder. This commit adds the path of the imported connector to the mediator list to support deletion of imported connectors.

Fixes: https://github.com/wso2/mi-vscode/issues/805