### PR TITLE
Add old mediator form support in MI 4.4.0

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/mediators/ForeachMediator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/mediators/ForeachMediator.java
@@ -101,6 +101,7 @@ public class ForeachMediator {
         }
         data.put("prevSequenceType", data.get("sequenceType"));
         data.put(Constant.VERSION, "v1");
+        data.put(Constant.UI_SCHEMA_NAME, "foreach_430");
         return data;
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/mediators/LogMediator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/mediators/LogMediator.java
@@ -21,6 +21,7 @@ package org.eclipse.lemminx.customservice.synapse.mediatorService.mediators;
 import org.eclipse.lemminx.customservice.synapse.mediatorService.MediatorUtils;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.mediator.core.Log;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.mediator.core.MediatorProperty;
+import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -108,6 +109,7 @@ public class LogMediator {
         }
         if (node.getLevel() != null) {
             data.put("level", node.getLevel().toUpperCase());
+            data.put(Constant.UI_SCHEMA_NAME, "log_430");
         }
         data.put("message", node.getMessage());
         data.put("description", node.getDescription());

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/mediators/PayloadFactoryMediator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/mediators/PayloadFactoryMediator.java
@@ -121,7 +121,7 @@ public class PayloadFactoryMediator {
                                                                                            List<String> dirtyFields) {
 
         Boolean useTemplateResource = (Boolean) data.get("useTemplateResource");
-        if (!useTemplateResource) {
+        if (useTemplateResource == null || !useTemplateResource) {
             data.put("isInlined", true);
         }
         // Process args
@@ -168,6 +168,7 @@ public class PayloadFactoryMediator {
             }
             data.put(Constant.ARGS, args);
             data.put(CONTAIN_ARGS, true);
+            data.put(Constant.UI_SCHEMA_NAME, "payloadFactory_430");
         }
         return data;
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -556,4 +556,5 @@ public class Constant {
     public static final String CAR_PLUGIN_CHECK_VERSION = "5.2.88";
     public static final String CONNECTOR_PATH = "connectorPath";
     public static final String MI_440_VERSION = "4.4.0";
+    public static final String UI_SCHEMA_NAME = "UI_SCHEMA_NAME";
 }

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/foreach.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/foreach.json
@@ -24,12 +24,7 @@
         "displayName": "Collection to iterate",
         "inputType": "expression",
         "required": true,
-        "helpTip": "The collection to iterate over. This can be a JSON array or XML list",
-        "enableCondition": [
-          {
-            "version": "v2"
-          }
-        ]
+        "helpTip": "The collection to iterate over. This can be a JSON array or XML list"
       }
     },
     {
@@ -40,12 +35,7 @@
         "inputType": "checkbox",
         "defaultValue": true,
         "required": false,
-        "helpTip": "If enabled, the messages will be processed in parallel. If disabled, the messages will be processed sequentially.",
-        "enableCondition": [
-          {
-            "version": "v2"
-          }
-        ]
+        "helpTip": "If enabled, the messages will be processed in parallel. If disabled, the messages will be processed sequentially."
       }
     },
     {
@@ -56,12 +46,7 @@
         "inputType": "checkbox",
         "defaultValue": false,
         "required": false,
-        "helpTip": "If enabled, the parent flow will continue without waiting for the aggregation.",
-        "enableCondition": [
-          {
-            "version": "v2"
-          }
-        ]
+        "helpTip": "If enabled, the parent flow will continue without waiting for the aggregation."
       }
     },
     {
@@ -69,10 +54,6 @@
       "value": {
         "groupName": "Output Configurations",
         "enableCondition": [
-          "AND",
-          {
-            "version": "v2"
-          },
           {
             "continueWithoutAggregation": false
           }
@@ -153,10 +134,6 @@
         "groupName": "Advanced",
         "isCollapsed": "true",
         "enableCondition": [
-          "AND",
-          {
-            "version": "v2"
-          },
           {
             "parallelExecution": false
           }
@@ -171,81 +148,6 @@
               "defaultValue": "",
               "required": "false",
               "helpTip": "You can access the current iteration number using this variable within the ForEach mediator."
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "attribute",
-      "value": {
-        "name": "forEachID",
-        "displayName": "ForEach ID",
-        "inputType": "string",
-        "required": false,
-        "helpTip": "",
-        "enableCondition": [
-          {
-            "version": "v1"
-          }
-        ]
-      }
-    },
-    {
-      "type": "attribute",
-      "value": {
-        "name": "forEachExpression",
-        "displayName": "ForEach Expression",
-        "inputType": "expression",
-        "expressionType":"xpath/jsonPath",
-        "required": true,
-        "helpTip": "",
-        "enableCondition": [
-          {
-            "version": "v1"
-          }
-        ]
-      }
-    },
-    {
-      "type": "attributeGroup",
-      "value": {
-        "groupName": "Sequence",
-        "enableCondition": [
-          {
-            "version": "v1"
-          }
-        ],
-        "elements": [
-          {
-            "type": "attribute",
-            "value": {
-              "name": "sequenceType",
-              "displayName": "Sequence Type",
-              "inputType": "combo",
-              "defaultValue": "Anonymous",
-              "comboValues": [
-                "Anonymous",
-                "Key"
-              ],
-              "required": false,
-              "helpTip": ""
-            }
-          },
-          {
-            "type": "attribute",
-            "value": {
-              "name": "sequenceKey",
-              "displayName": "Sequence Key",
-              "inputType": "key",
-              "enableCondition": [
-                {
-                  "sequenceType": "Key"
-                }
-              ],
-              "required": false,
-              "helpTip": "",
-              "keyType": "sequence"
             }
           }
         ]

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/foreach_430.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/foreach_430.json
@@ -1,0 +1,79 @@
+{
+  "name": "ForEachMediator",
+  "type": "mediator",
+  "title": "ForEach Mediator",
+  "help": "Splits message based on XPath/JSONPath, processes sequentially, then merges back.",
+  "banner": "This is an old version of the Foreach mediator. Please migrate to the new version.",
+  "elements": [
+    {
+      "type": "attribute",
+      "value": {
+        "name": "forEachID",
+        "displayName": "ForEach ID",
+        "inputType": "string",
+        "required": false,
+        "helpTip": ""
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "forEachExpression",
+        "displayName": "ForEach Expression",
+        "inputType": "expression",
+        "expressionType": "xpath/jsonPath",
+        "required": true,
+        "helpTip": ""
+      }
+    },
+    {
+      "type": "attributeGroup",
+      "value": {
+        "groupName": "Sequence",
+        "elements": [
+          {
+            "type": "attribute",
+            "value": {
+              "name": "sequenceType",
+              "displayName": "Sequence Type",
+              "inputType": "combo",
+              "defaultValue": "Anonymous",
+              "comboValues": [
+                "Anonymous",
+                "Key"
+              ],
+              "required": false,
+              "helpTip": ""
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "sequenceKey",
+              "displayName": "Sequence Key",
+              "inputType": "key",
+              "enableCondition": [
+                {
+                  "sequenceType": "Key"
+                }
+              ],
+              "required": false,
+              "helpTip": "",
+              "keyType": "sequence"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "description",
+        "displayName": "Description",
+        "inputType": "string",
+        "required": false,
+        "helpTip": ""
+      }
+    }
+  ]
+}

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/log.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/log.json
@@ -27,37 +27,6 @@
     {
       "type": "attribute",
       "value": {
-        "name": "level",
-        "displayName": "Log Level",
-        "inputType": "combo",
-        "comboValues": [
-          "SIMPLE",
-          "HEADERS",
-          "FULL",
-          "CUSTOM"
-        ],
-        "required": "false",
-        "helpTip": "Log Level",
-        "enableCondition": [
-          "OR",
-          {
-            "level": "SIMPLE"
-          },
-          {
-            "level": "HEADERS"
-          },
-          {
-            "level": "FULL"
-          },
-          {
-            "level": "CUSTOM"
-          }
-        ]
-      }
-    },
-    {
-      "type": "attribute",
-      "value": {
         "name": "message",
         "displayName": "Message",
         "inputType": "expressionTextArea",

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/log_430.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/log_430.json
@@ -1,0 +1,100 @@
+{
+  "name": "log",
+  "type": "mediator",
+  "title": "Log Mediator",
+  "help": "Generates logs for messages. Log details are customisable.",
+  "banner": "This is an old version of the Log mediator. Please migrate to the new version.",
+  "elements": [
+    {
+      "type": "attribute",
+      "value": {
+        "name": "category",
+        "displayName": "Log Category",
+        "inputType": "combo",
+        "defaultValue": "INFO",
+        "comboValues": [
+          "INFO",
+          "TRACE",
+          "DEBUG",
+          "WARN",
+          "ERROR",
+          "FATAL"
+        ],
+        "required": "true",
+        "helpTip": "Log Category"
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "level",
+        "displayName": "Log Level",
+        "inputType": "combo",
+        "defaultValue": "SIMPLE",
+        "comboValues": [
+          "SIMPLE",
+          "HEADERS",
+          "FULL",
+          "CUSTOM"
+        ],
+        "required": "true",
+        "helpTip": "Log Level"
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "separator",
+        "displayName": "Log Separator",
+        "inputType": "string",
+        "defaultValue": "",
+        "required": "false",
+        "helpTip": ""
+      }
+    },
+    {
+      "type": "table",
+      "value": {
+        "name": "properties",
+        "displayName": "Properties",
+        "description": "Editing of the properties of an object LogProperty",
+        "tableKey": "propertyName",
+        "tableValue": "propertyValue",
+        "elements": [
+          {
+            "type": "attribute",
+            "value": {
+              "name": "propertyName",
+              "displayName": "Property Name",
+              "inputType": "string",
+              "required": false,
+              "helpTip": ""
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "propertyValue",
+              "displayName": "Property Value",
+              "inputType": "stringOrExpression",
+              "expressionType": "xpath/jsonPath",
+              "required": false,
+              "helpTip": ""
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "description",
+        "displayName": "Description",
+        "inputType": "string",
+        "defaultValue": "",
+        "required": "false",
+        "helpTip": "Description"
+      }
+    }
+  ]
+}

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/payloadFactory.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/payloadFactory.json
@@ -55,67 +55,6 @@
                 ]
               }
             }
-          },
-          {
-            "type": "table",
-            "value": {
-              "name": "args",
-              "displayName": "Arguments",
-              "title": "Payload Factory Argument",
-              "description": "Arguments to be passed to the payload factory.",
-              "tableKey": "{row.number}",
-              "tableValue": "argumentValue",
-              "enableCondition": [
-                {
-                  "containArgs": true
-                }
-              ],
-              "elements": [
-                {
-                  "type": "attribute",
-                  "value": {
-                    "name": "argumentValue",
-                    "displayName": "Argument Value",
-                    "inputType": "stringOrExpression",
-                    "expressionType":"xpath/jsonPath",
-                    "defaultValue": "",
-                    "required": false,
-                    "helpTip": ""
-                  }
-                },
-                {
-                  "type": "attribute",
-                  "value": {
-                    "name": "evaluator",
-                    "displayName": "Evaluator",
-                    "inputType": "combo",
-                    "defaultValue": "xml",
-                    "comboValues": [
-                      "xml",
-                      "json"
-                    ],
-                    "required": false,
-                    "enableCondition": [
-                      {
-                        "argumentValue.isExpression": true
-                      }
-                    ],
-                    "helpTip": ""
-                  }
-                },
-                {
-                  "type": "attribute",
-                  "value": {
-                    "name": "literal",
-                    "displayName": "Literal",
-                    "inputType": "checkbox",
-                    "defaultValue": false,
-                    "required": false,
-                    "helpTip": ""
-                  }
-                }
-              ]
-            }
           }
         ]
       }
@@ -158,7 +97,12 @@
               "name": "payloadKey",
               "displayName": "Resource Key",
               "inputType": "resource",
-              "keyType": ["xml", "json", "txt", "ftl"],
+              "keyType": [
+                "xml",
+                "json",
+                "txt",
+                "ftl"
+              ],
               "required": true,
               "helpTip": "",
               "enableCondition": [
@@ -170,18 +114,6 @@
             }
           }
         ]
-      }
-    },
-    {
-      "type": "attribute",
-      "value": {
-        "name": "containArgs",
-        "displayName": "containArgs",
-        "inputType": "checkbox",
-        "defaultValue": false,
-        "required": false,
-        "helpTip": "",
-        "hidden": true
       }
     },
     {

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/payloadFactory_430.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/payloadFactory_430.json
@@ -1,0 +1,182 @@
+{
+  "name": "Payload",
+  "type": "mediator",
+  "title": "Payload Mediator",
+  "help": "Replaces message payload with a new SOAP/JSON payload.",
+  "banner": "This is an old version of the Payload Factory mediator. Please migrate to the new version.",
+  "canTryout": true,
+  "elements": [
+    {
+      "type": "attribute",
+      "value": {
+        "name": "payloadFormat",
+        "displayName": "Payload Format",
+        "inputType": "combo",
+        "defaultValue": "Inline",
+        "comboValues": [
+          "Inline",
+          "Registry Reference"
+        ],
+        "required": false,
+        "helpTip": ""
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "mediaType",
+        "displayName": "Media Type",
+        "inputType": "combo",
+        "defaultValue": "json",
+        "comboValues": [
+          "xml",
+          "json",
+          "text"
+        ],
+        "required": false,
+        "helpTip": ""
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "templateType",
+        "displayName": "Template Type",
+        "inputType": "combo",
+        "defaultValue": "Default",
+        "comboValues": [
+          "Default",
+          "Freemarker"
+        ],
+        "required": false,
+        "helpTip": ""
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "payloadKey",
+        "displayName": "Payload Key",
+        "inputType": "resource",
+        "keyType": [
+          "xml",
+          "json",
+          "txt",
+          "ftl"
+        ],
+        "defaultValue": "",
+        "required": true,
+        "helpTip": "",
+        "enableCondition": [
+          {
+            "payloadFormat": "Registry Reference"
+          }
+        ]
+      }
+    },
+    {
+      "type": "attributeGroup",
+      "value": {
+        "groupName": "Payload",
+        "elements": [
+          {
+            "type": "attribute",
+            "value": {
+              "name": "payload",
+              "displayName": "Payload",
+              "inputType": "codeTextArea",
+              "defaultValue": "",
+              "required": true,
+              "placeholder": {
+                "conditionField": "mediaType",
+                "values": [
+                  {
+                    "xml": "<inline/>"
+                  },
+                  {
+                    "json": "{\"Inline\":\"json\"}"
+                  },
+                  {
+                    "text": "Inline text"
+                  }
+                ]
+              },
+              "enableCondition": [
+                {
+                  "payloadFormat": "Inline"
+                }
+              ]
+            }
+          },
+          {
+            "type": "table",
+            "value": {
+              "name": "args",
+              "displayName": "Args",
+              "title": "Payload Factory Argument",
+              "description": "Editing of the properties of an object Payload Factory Argument",
+              "tableKey": "{row.number}",
+              "tableValue": "argumentValue",
+              "elements": [
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "argumentValue",
+                    "displayName": "Argument Value",
+                    "inputType": "stringOrExpression",
+                    "expressionType": "xpath/jsonPath",
+                    "defaultValue": "",
+                    "required": false,
+                    "helpTip": ""
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "evaluator",
+                    "displayName": "Evaluator",
+                    "inputType": "combo",
+                    "defaultValue": "xml",
+                    "comboValues": [
+                      "xml",
+                      "json"
+                    ],
+                    "required": false,
+                    "enableCondition": [
+                      {
+                        "argumentValue.isExpression": true
+                      }
+                    ],
+                    "helpTip": ""
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "literal",
+                    "displayName": "Literal",
+                    "inputType": "checkbox",
+                    "defaultValue": false,
+                    "required": false,
+                    "helpTip": ""
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "description",
+        "displayName": "Description",
+        "inputType": "string",
+        "defaultValue": "",
+        "required": false,
+        "helpTip": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Currently, the hybrid form allows editing a mix of old and new configurations for the revamped mediators. This inconsistency creates confusion for users migrating to the new format, as the form structure differs based on the configuration. This PR addresses the issue by separating the old and new mediator forms.