### PR TITLE
Fix response variable default value numbering

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -496,7 +496,7 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     @Override
     public CompletableFuture<JsonObject> getMediatorUISchema(UISchemaRequest uiSchemaRequest) {
 
-        return CompletableFuture.supplyAsync(() -> mediatorHandler.getUiSchema(uiSchemaRequest.mediatorType));
+        return CompletableFuture.supplyAsync(() -> mediatorHandler.getUiSchema(uiSchemaRequest.mediatorType, uiSchemaRequest.documentIdentifier, uiSchemaRequest.position));
     }
 
     @Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/expression/ExpressionHelperProvider.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/expression/ExpressionHelperProvider.java
@@ -42,6 +42,8 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -105,10 +107,11 @@ public class ExpressionHelperProvider {
             return getBasicHelperData();
         }
         try {
+            URI documentTruePath = new URI(param.getDocumentUri());
             Position position =
-                    ExpressionCompletionUtils.getLastMediatorPosition(param.getDocumentUri(), param.getPosition());
-            return getExpressionHelperData(new ExpressionParam(param.getDocumentUri(), position));
-        } catch (IOException e) {
+                    ExpressionCompletionUtils.getLastMediatorPosition(documentTruePath.getPath(), param.getPosition());
+            return getExpressionHelperData(new ExpressionParam(documentTruePath.getPath(), position));
+        } catch (IOException | URISyntaxException e) {
             return getBasicHelperData();
         }
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/MediatorUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/MediatorUtils.java
@@ -1,11 +1,40 @@
 package org.eclipse.lemminx.customservice.synapse.mediatorService;
 
+import org.eclipse.lemminx.customservice.synapse.expression.ExpressionHelperProvider;
+import org.eclipse.lemminx.customservice.synapse.expression.pojo.ExpressionParam;
+import org.eclipse.lemminx.customservice.synapse.expression.pojo.HelperPanelData;
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.Namespace;
 import org.eclipse.lemminx.customservice.synapse.utils.Constant;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 
+import java.io.IOException;
 import java.util.*;
 
 public class MediatorUtils {
+
+    public static String generateResponseVariableDefaultValue(TextDocumentIdentifier documentIdentifier, Position position, String connectorName, String operationName)
+            throws IOException {
+
+        ExpressionHelperProvider expressionHelperProvider = new ExpressionHelperProvider("");
+        ExpressionParam expressionParam = new ExpressionParam(documentIdentifier.getUri(), position);
+        HelperPanelData lastMediatorHelperData = expressionHelperProvider.getLastMediatorHelperData(expressionParam);
+        List<CompletionItem> variables = lastMediatorHelperData.getVariables();
+        int usedMaxDigit = 1;
+        for (CompletionItem variable : variables) {
+            String variableName = variable.getLabel();
+            if (variableName.startsWith(String.format("%s_%s_", connectorName, operationName))) {
+                String digitPart = variableName.split("_")[2];
+                try {
+                    usedMaxDigit = Math.max(usedMaxDigit, Integer.parseInt(digitPart));
+                } catch (NumberFormatException ignored) {
+                    continue;
+                }
+            }
+        }
+        return String.format("%s_%s_%s", connectorName, operationName, usedMaxDigit + 1);
+    }
 
     public static List<Namespace> transformNamespaces(Map<String, String> namespaces) {
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/pojo/UISchemaRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/pojo/UISchemaRequest.java
@@ -18,7 +18,12 @@
 
 package org.eclipse.lemminx.customservice.synapse.mediatorService.pojo;
 
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
 public class UISchemaRequest {
 
     public String mediatorType;
+    public TextDocumentIdentifier documentIdentifier;
+    public Position position;
 }


### PR DESCRIPTION
## Purpose
When adding a connector operation, we add a default value for the new response variable name. Currently it is populated as `<connector_name>_<operation_name>_<random_number>`. With this change, we will look into the above defined variables and generate default value of response variable in a ordered manner as `<connector_name>_<operation_name>_1`, `<connector_name>_<operation_name>_2`, ... . 