### PR TITLE
Update Log mediator UI with option to log message ID and full payload

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/mediators/LogMediator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/mediators/LogMediator.java
@@ -114,6 +114,8 @@ public class LogMediator {
         data.put("message", node.getMessage());
         data.put("description", node.getDescription());
         data.put("separator", node.getSeparator());
+        data.put(Constant.LOG_FULL_PAYLOAD, node.isLogFullPayload());
+        data.put(Constant.LOG_MESSAGE_ID, node.isLogMessageID());
         if (node.getProperty() != null) {
             List<List<Object>> properties = new ArrayList<>();
             for (MediatorProperty property : node.getProperty()) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/mediators/core/LogFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/mediators/core/LogFactory.java
@@ -78,6 +78,18 @@ public class LogFactory extends AbstractMediatorFactory {
             if (description != null) {
                 ((Log) node).setDescription(description);
             }
+            String logMessageIDAttr = element.getAttribute(Constant.LOG_MESSAGE_ID);
+            if (logMessageIDAttr != null) {
+                ((Log) node).setLogMessageID(Boolean.parseBoolean(logMessageIDAttr));
+            } else {
+                ((Log) node).setLogMessageID(false);
+            }
+            String logFullPayloadAttr = element.getAttribute(Constant.LOG_FULL_PAYLOAD);
+            if (logFullPayloadAttr != null) {
+                ((Log) node).setLogFullPayload(Boolean.parseBoolean(logFullPayloadAttr));
+            } else {
+                ((Log) node).setLogFullPayload(false);
+            }
         } catch (IllegalArgumentException e) {
             // ignore
         }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/mediator/core/Log.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/pojo/mediator/core/Log.java
@@ -28,6 +28,8 @@ public class Log extends Mediator {
     LogCategory category;
     String description;
     String message;
+    boolean logFullPayload;
+    boolean logMessageID;
 
     public Log() {
         setDisplayName("Log");
@@ -91,5 +93,25 @@ public class Log extends Mediator {
     public void setMessage(String message) {
 
         this.message = message;
+    }
+
+    public boolean isLogFullPayload() {
+
+        return logFullPayload;
+    }
+
+    public void setLogFullPayload(boolean logFullPayload) {
+
+        this.logFullPayload = logFullPayload;
+    }
+
+    public boolean isLogMessageID() {
+
+        return logMessageID;
+    }
+
+    public void setLogMessageID(boolean logMessageID) {
+
+        this.logMessageID = logMessageID;
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -559,4 +559,6 @@ public class Constant {
     public static final String UI_SCHEMA_NAME = "UI_SCHEMA_NAME";
     public static final String SEQUENCE_NAME = "sequenceName";
     public static final String CAN_TRY_OUT = "canTryOut";
+    public static final String LOG_MESSAGE_ID = "logMessageID";
+    public static final String LOG_FULL_PAYLOAD = "logFullPayload";
 }

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/templates/log.mustache
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/templates/log.mustache
@@ -1,4 +1,4 @@
-<log {{#category}}category="{{category}}"{{/category}} {{#level}}level="{{level}}"{{/level}} {{#separator}}separator="{{separator}}"{{/separator}} {{#description}}description="{{description}}"{{/description}}>
+<log {{#category}}category="{{category}}"{{/category}} {{#level}}level="{{level}}"{{/level}} {{#separator}}separator="{{separator}}"{{/separator}} logMessageID="{{logMessageID}}" logFullPayload="{{logFullPayload}}" {{#description}}description="{{description}}"{{/description}}>
     <message>{{message}}</message>
     {{#properties}}
         <property name="{{propertyName}}" {{#value}}value="{{value}}"{{/value}} {{#expression}}expression="{{expression}}" {{#namespaces}} xmlns:{{prefix}}="{{uri}}"{{/namespaces}} {{/expression}} />

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/log.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/mediators/440/ui-schemas/log.json
@@ -27,6 +27,28 @@
     {
       "type": "attribute",
       "value": {
+        "name": "logMessageID",
+        "displayName": "Append Message ID",
+        "inputType": "checkbox",
+        "defaultValue": "false",
+        "helpTip": "Logs the Message ID alongside other selected details.",
+        "required": "false"
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
+        "name": "logFullPayload",
+        "displayName": "Append Payload",
+        "inputType": "checkbox",
+        "defaultValue": "false",
+        "helpTip": "Logs the full message payload alongside other selected details.",
+        "required": "false"
+      }
+    },
+    {
+      "type": "attribute",
+      "value": {
         "name": "message",
         "displayName": "Message",
         "inputType": "expressionTextArea",

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/schemas/440/mediators/core/log.xsd
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/schemas/440/mediators/core/log.xsd
@@ -43,6 +43,8 @@
             <xs:attribute name="separator" type="xs:string" use="optional" default=", "/>
             <xs:attribute name="category" type="logCategory" use="optional" default="INFO"/>
             <xs:attribute name="description" type="xs:string" use="optional"/>
+            <xs:attribute name="logMessageID" type="xs:boolean" use="optional"/>
+            <xs:attribute name="logFullPayload" type="xs:boolean" use="optional"/>
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
## Purpose

Update Log mediator UI with option to log message ID and full payload.

![Screenshot 2025-02-20 at 11 53 06](https://github.com/user-attachments/assets/90cd3e90-086e-4be0-a89a-da3576202002)

Synapse XML

```xml
<log category="INFO" logMessageID="false" logFullPayload="false">
    <message>Hello 1</message>
</log>
<log category="INFO" logMessageID="false" logFullPayload="true">
    <message></message>
</log>
```
