### PR TITLE
Add integration type categorization for project

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -495,6 +495,13 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     }
 
     @Override
+    public CompletableFuture<List<String>> getProjectIntegrationType(WorkspaceFolder param) {
+
+        List<String> response = OverviewPage.getProjectIntegrationType(param);
+        return CompletableFuture.supplyAsync(() -> response);
+    }
+
+    @Override
     public CompletableFuture<JsonObject> getMediators(MediatorRequest mediatorRequest) {
 
         return CompletableFuture.supplyAsync(() -> mediatorHandler.getSupportedMediators(mediatorRequest.documentIdentifier, mediatorRequest.position));

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
@@ -191,6 +191,9 @@ public interface ISynapseLanguageService {
     CompletableFuture<DirectoryMapResponse> getProjectExplorerModel(WorkspaceFolder param);
 
     @JsonRequest
+    CompletableFuture<List<String>> getProjectIntegrationType(WorkspaceFolder param);
+
+    @JsonRequest
     CompletableFuture<JsonObject> getMediators(MediatorRequest mediatorRequest);
 
     @JsonRequest

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/directoryTree/DirectoryTreeBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/directoryTree/DirectoryTreeBuilder.java
@@ -232,15 +232,21 @@ public class DirectoryTreeBuilder {
         if (pomFile.exists()) {
             try {
                 DOMDocument pom = Utils.getDOMDocument(pomFile);
-                if (pom != null && pom.getDocumentElement() != null) {
-                    DOMNode properties = Utils.getChildNodeByName(pom.getDocumentElement(), Constant.PROPERTIES);
-                    if (properties != null) {
-                        DOMNode mainSequenceElt = Utils.getChildNodeByName(properties, "mainSequence");
-                        if (mainSequenceElt != null) {
-                            mainSequence = Utils.getInlineString(mainSequenceElt.getFirstChild());
+                DOMNode profiles = Utils.getChildNodeByName(pom.getDocumentElement(), Constant.PROFILES);
+                List<DOMNode> profileList = profiles.getChildren();
+                profileList.forEach(profile -> {
+                    DOMNode profileId = Utils.getChildNodeByName(profile, Constant.ID);
+                    if (profileId != null && Constant.DEFAULT.equals(Utils.getInlineString(profileId.getFirstChild()))) {
+                        DOMNode properties = Utils.getChildNodeByName(profile, Constant.PROPERTIES);
+                        if (properties != null) {
+                            DOMNode mainSequenceNode = Utils.getChildNodeByName(properties, Constant.MAIN_SEQUENCE);
+                            if (mainSequenceNode != null) {
+                                mainSequence = Utils.getInlineString(mainSequenceNode.getFirstChild());
+                                return;
+                            }
                         }
                     }
-                }
+                });
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Could not read project pom file");
             }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -568,4 +568,14 @@ public class Constant {
     public static final String JSON_FILE_EXT = ".json";
     public static final String INBOUND_CONNECTOR_PREFIX = "mi-inbound-";
     public static final String INBOUND_CONNECTORS = "inbound.connectors";
+    public static final String DEVANT_API = "INTEGRATION_AS_API";
+    public static final String DEVANT_AUTOMATION = "AUTOMATION";
+    public static final String DEVANT_EVENT = "EVENT_INTEGRATION";
+    public static final String EVENT_INTEGRATIONS = "Event Integrations";
+    public static final String OTHER_ARTIFACTS = "Other Artifacts";
+    public static final String SEQUENCE_ARTIFACTS = "Sequences";
+    public static final String API_ARTIFACTS = "APIs";
+    public static final String IS_MAIN_SEQUENCE = "isMainSequence";
+    public static final String PROFILES = "profiles";
+    public static final String MAIN_SEQUENCE = "mainSequence";
 }


### PR DESCRIPTION
This PR will add the capability to get the integration types that can be supported using the project based on the artifacts that exist within it so that those types can be used when creating a Devant component to deploy the project.