### PR TITLE
Add unit tests for DirectoryTreeBuilder

### DIFF
--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/directorytree/builder/DirectoryTreeBuilderTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/directorytree/builder/DirectoryTreeBuilderTest.java
@@ -32,9 +32,13 @@ import org.mockito.MockedStatic;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mockStatic;
 
@@ -95,6 +99,32 @@ public class DirectoryTreeBuilderTest {
         connectorHolderMock.close();
 
         assertNull(result);
+    }
+
+    @Test
+    void getProjectIdentifiersWithArtifactList() {
+        String resourcePath = "/synapse/resource.finder/test_project";
+        String projectPath = new File(DirectoryTreeBuilderTest.class.getResource(resourcePath).getPath()).getAbsolutePath();
+        String apiPath = new File(DirectoryTreeBuilderTest.class.getResource(resourcePath + "/src/main/wso2mi/artifacts/apis/testApi.xml").
+                getPath()).getAbsolutePath();
+        String sequencePath = new File(DirectoryTreeBuilderTest.class.getResource(resourcePath + "/src/main/wso2mi/artifacts/sequences/testSequence1.xml")
+                .getPath()).getAbsolutePath();
+        List<String> artifactIdentifierList = Arrays.asList("apis/testApi", "sequences/testSequence1");
+        List<String> result = DirectoryTreeBuilder.getProjectIdentifiers(new WorkspaceFolder(projectPath),
+                Arrays.asList(apiPath, sequencePath));
+        connectorHolderMock.close();
+
+        assertEquals(artifactIdentifierList, result);
+    }
+
+    @Test
+    void getProjectIdentifiersWithEmptyArtifactList() {
+        String path = DirectoryTreeBuilderTest.class.getResource("/synapse/resource.finder/test_project").getPath();
+        String projectPath = new File(path).getAbsolutePath();
+        List<String> result = DirectoryTreeBuilder.getProjectIdentifiers(new WorkspaceFolder(projectPath), new ArrayList<>());
+        connectorHolderMock.close();
+
+        assertTrue(result.isEmpty());
     }
 
     private static JsonObject sanitizeJson(JsonObject jsonObject) {


### PR DESCRIPTION
This PR will add unit tests for the DirectoryTreeBuilder class.

Issue: https://github.com/wso2/mi-vscode/issues/441