### PR TITLE
Add length validation in getAttribute.

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.eclipse.lemminx</groupId>
 		<artifactId>lemminx-parent</artifactId>
-		<version>0.24.0-wso2v59-SNAPSHOT</version>
+		<version>0.24.0-wso2v60-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>org.eclipse.lemminx</artifactId>

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
@@ -375,7 +375,7 @@ public abstract class DOMNode implements Node, DOMRange {
 		}
 		// remove quote
 		char c = value.charAt(0);
-		if (c == '"' || c == '\'') {
+		if ((c == '"' || c == '\'') && value.length() > 1) {
 			if (value.charAt(value.length() - 1) == c) {
 				return value.substring(1, value.length() - 1);
 			}

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.lemminx</groupId>
 	<artifactId>lemminx-parent</artifactId>
-	<version>0.24.0-wso2v59-SNAPSHOT</version>
+	<version>0.24.0-wso2v60-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Eclipse LemMinX</name>
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>


### PR DESCRIPTION
## Purpose
This will prevent error when xml like this
```xml
            <property name="apos" scope="default" type="STRING" value="'"/>
```