### PR TITLE
Generate API swagger based on the server offset

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/OpenAPIProcessor.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/OpenAPIProcessor.java
@@ -81,11 +81,11 @@ public class OpenAPIProcessor {
      * @param isJSON response data type JSON / YAML.
      * @return OpenAPI definition as string.
      */
-    public String getOpenAPISpecification(final boolean isJSON) {
+    public String getOpenAPISpecification(final boolean isJSON, final int port) {
 
         final OpenAPI openAPI = new OpenAPI();
         addInfoSection(openAPI);
-        addServersSection(openAPI);
+        addServersSection(openAPI, port);
         // Re-use the previous implementation to get resource details of the API.
         final Map<String, Object> dataMap = GenericApiObjectDefinition.getPathMap(api);
         Paths paths = new Paths();
@@ -196,7 +196,7 @@ public class OpenAPIProcessor {
                 }
             }
         } else {
-            addServersSection(openAPI);
+            addServersSection(openAPI, SwaggerConstants.DEFAULT_PORT);
         }
     }
 
@@ -205,7 +205,7 @@ public class OpenAPIProcessor {
      *
      * @param openAPI OpenApi object.
      */
-    private void addServersSection(OpenAPI openAPI) {
+    private void addServersSection(OpenAPI openAPI, int port) {
 
         String basePath;
         if (ApiVersionType.url.equals(api.getVersionType())) {
@@ -218,7 +218,7 @@ public class OpenAPIProcessor {
         if (StringUtils.isNotBlank(api.getHostname()) && !"-1".equals(api.getPort())) {
             host = api.getHostname() + ":" + api.getPort();
         } else {
-            host = SwaggerConstants.DEFAULT_HOST + ":" + SwaggerConstants.DEFAULT_PORT;
+            host = SwaggerConstants.DEFAULT_HOST + ":" + port;
         }
         Server server = new Server();
         server.setUrl(scheme + "://" + host + basePath);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/RestApiAdmin.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/RestApiAdmin.java
@@ -355,7 +355,7 @@ public class RestApiAdmin {
                         param.apiPath);
             }
         }
-        return generateSwaggerFromSynapseAPIByFormat(param.apiPath, param.isJsonOut);
+        return generateSwaggerFromSynapseAPIByFormat(param.apiPath, param.isJsonOut, param.port);
     }
 
     /**
@@ -364,7 +364,7 @@ public class RestApiAdmin {
      * @param apiPath API file path
      * @return generated API
      */
-    public GenerateSwaggerResponse generateSwaggerFromSynapseAPIByFormat(String apiPath, boolean isJSON) {
+    public GenerateSwaggerResponse generateSwaggerFromSynapseAPIByFormat(String apiPath, boolean isJSON, int port) {
 
         GenerateSwaggerResponse response = new GenerateSwaggerResponse();
         try {
@@ -372,7 +372,7 @@ public class RestApiAdmin {
             DOMDocument domDocument = Utils.getDOMDocument(apiFile);
             APIFactory factory = new APIFactory();
             API api = (API) factory.create(domDocument.getDocumentElement());
-            String generatedSwagger = generateSwaggerFromSynapseAPIByFormat(api, isJSON);
+            String generatedSwagger = generateSwaggerFromSynapseAPIByFormat(api, isJSON, port);
             response.setSwagger(generatedSwagger);
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Error occurred while reading the existing API file.", e);
@@ -388,9 +388,9 @@ public class RestApiAdmin {
      * @param isJSON generate Swagger in YAML / JSON format.
      * @return generated swagger.
      */
-    public String generateSwaggerFromSynapseAPIByFormat(API api, boolean isJSON) {
+    public String generateSwaggerFromSynapseAPIByFormat(API api, boolean isJSON, int port) {
 
-        return new OpenAPIProcessor(api).getOpenAPISpecification(isJSON);
+        return new OpenAPIProcessor(api).getOpenAPISpecification(isJSON, port);
     }
 
     private GenerateSwaggerResponse generateUpdatedSwaggerFromAPI(File existingSwaggerFile, boolean isJSONIn,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/pojo/GenerateSwaggerParam.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/pojo/GenerateSwaggerParam.java
@@ -18,10 +18,13 @@
 
 package org.eclipse.lemminx.customservice.synapse.api.generator.pojo;
 
+import org.eclipse.lemminx.customservice.synapse.api.generator.SwaggerConstants;
+
 public class GenerateSwaggerParam {
 
     public String apiPath;
     public String swaggerPath;
     public boolean isJsonIn;
     public boolean isJsonOut;
+    public int port = SwaggerConstants.DEFAULT_PORT;
 }


### PR DESCRIPTION
This PR will generate the API swagger used for the runtime services panel in the MI extension based on the given server offset.

Related issue: https://github.com/wso2/mi-vscode/issues/1076