### PR TITLE
Handle getting JSON inputs for string and inline expression fields in connectors

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/MediatorHandler.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/mediatorService/MediatorHandler.java
@@ -211,7 +211,13 @@ public class MediatorHandler {
         Map<String, Object> dataValue = new HashMap<>();
         boolean isExpressionField = false;
         if (data instanceof String) {
-            dataValue.put(Constant.VALUE, String.format("%s", data));
+            String dataStr = (String) data;
+            String trimmedDataStr = dataStr.trim();
+            if (trimmedDataStr.startsWith("{") && trimmedDataStr.endsWith("}")) {
+                dataValue.put(Constant.VALUE, String.format("'%s'", trimmedDataStr));
+            } else {
+                dataValue.put(Constant.VALUE, String.format("%s", data));
+            }
         } else if (data instanceof Boolean) {
             dataValue.put(Constant.VALUE, data);
         } else if (data instanceof Map) {


### PR DESCRIPTION
## Purpose
Having a value with curly braces(`{....}`) for a field in connector, will try to resolve it as an expression. Making it unable to provide a JSON value for a string or inline expression field. Hence it will be handled by wrapping the JSON content with single quotes(ex: `'{"name":"Alice","age":25}'`).  