### PR TITLE
Add support for maven-car-deploy plugin

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -65,6 +65,8 @@ import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.MediatorRe
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.SynapseConfigRequest;
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.SynapseConfigResponse;
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.UISchemaRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.Constants;
+import org.eclipse.lemminx.customservice.synapse.parser.DeployPluginDetails;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPage;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPageDetailsResponse;
 import org.eclipse.lemminx.customservice.synapse.parser.UpdateConfigRequest;
@@ -123,6 +125,7 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Either3;
@@ -667,6 +670,27 @@ public class SynapseLanguageService implements ISynapseLanguageService {
                 projectUri,
                 request.getConnectorName(),
                 request.getConnectionType()));
+    }
+
+    @Override
+    public CompletableFuture<DeployPluginDetails> updateMavenDeployPlugin(DeployPluginDetails pluginDetails) {
+
+        return CompletableFuture.supplyAsync(() -> PomParser.addCarDeployPluginToPom(
+                new File(projectUri + File.separator + Constants.POM_FILE), pluginDetails));
+    }
+
+    @Override
+    public CompletableFuture<DeployPluginDetails> getMavenDeployPluginDetails() {
+
+        return CompletableFuture.supplyAsync(() -> PomParser.extractCarDeployPluginFields(
+                new File(projectUri + File.separator + Constants.POM_FILE)));
+    }
+
+    @Override
+    public CompletableFuture<TextEdit> removeMavenDeployPlugin() {
+
+        return CompletableFuture.supplyAsync(() -> PomParser.removeDeployPlugin(
+                new File(projectUri + File.separator + Constants.POM_FILE)));
     }
 
     public String getProjectUri() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
@@ -55,6 +55,7 @@ import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.MediatorRe
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.SynapseConfigRequest;
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.SynapseConfigResponse;
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.UISchemaRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.DeployPluginDetails;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPageDetailsResponse;
 import org.eclipse.lemminx.customservice.synapse.parser.UpdateConfigRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.UpdateDependencyRequest;
@@ -75,6 +76,7 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Either3;
@@ -252,4 +254,13 @@ public interface ISynapseLanguageService {
 
     @JsonRequest
     CompletableFuture<String> downloadDriverForConnector(DriverDownloadRequest request);
+
+    @JsonRequest
+    CompletableFuture<DeployPluginDetails> updateMavenDeployPlugin(DeployPluginDetails request);
+
+    @JsonRequest
+    CompletableFuture<TextEdit> removeMavenDeployPlugin();
+
+    @JsonRequest
+    CompletableFuture<DeployPluginDetails> getMavenDeployPluginDetails();
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/dataService/QueryGenerateUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/dataService/QueryGenerateUtils.java
@@ -155,7 +155,7 @@ public class QueryGenerateUtils {
         definedTypeMap.put(Types.INTEGER, "INTEGER");
         definedTypeMap.put(Types.SMALLINT, "SMALLINT");
         definedTypeMap.put(Types.FLOAT, "DOUBLE");
-        definedTypeMap.put(Types.REAL, "REAL");
+        definedTypeMap.put(Types.REAL, "FLOAT");
         definedTypeMap.put(Types.DOUBLE, "DOUBLE");
         definedTypeMap.put(Types.VARCHAR, "STRING");
         definedTypeMap.put(Types.NVARCHAR, "STRING");
@@ -180,7 +180,7 @@ public class QueryGenerateUtils {
         qnameTypeMap.put(Types.INTEGER, "integer");
         qnameTypeMap.put(Types.SMALLINT, "integer");
         qnameTypeMap.put(Types.FLOAT, "float");
-        qnameTypeMap.put(Types.REAL, "double");
+        qnameTypeMap.put(Types.REAL, "float");
         qnameTypeMap.put(Types.DOUBLE, "double");
         qnameTypeMap.put(Types.VARCHAR, "string");
         qnameTypeMap.put(Types.NVARCHAR, "string");

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/Constants.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
     public static final String CONFIG_FILE = "config.properties";
     public static final String POM_FILE = "pom.xml";
     public static final String DEPENDENCY = "dependency";
+    public static final String PLUGINS = "plugins";
     public static final String PLUGIN = "plugin";
     public static final String REPOSITORY = "repository";
     public static final String PLUGIN_REPOSITORY = "pluginRepository";

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DeployPluginDetails.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DeployPluginDetails.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+package org.eclipse.lemminx.customservice.synapse.parser;
+
+import org.eclipse.lsp4j.TextEdit;
+
+public class DeployPluginDetails {
+
+    private String truststorePath;
+    private String truststorePassword;
+    private String truststoreType;
+    private String serverUrl;
+    private String username;
+    private String password;
+    private String serverType;
+    private TextEdit textEdit;
+
+    public DeployPluginDetails(TextEdit textEdit) {
+        this.textEdit = textEdit;
+    }
+
+    public DeployPluginDetails(String truststorePath, String truststorePassword, String truststoreType,
+            String serverUrl, String username, String password, String serverType) {
+        this.truststorePath = truststorePath;
+        this.truststorePassword = truststorePassword;
+        this.truststoreType = truststoreType;
+        this.serverUrl = serverUrl;
+        this.username = username;
+        this.password = password;
+        this.serverType = serverType;
+    }
+
+    public String getTruststorePath() {
+        return truststorePath;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    public String getTruststoreType() {
+        return truststoreType;
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getServerType() {
+        return serverType;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/pom/PluginHandler.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/pom/PluginHandler.java
@@ -58,10 +58,12 @@ public class PluginHandler extends DefaultHandler {
         valueStartLine = locator.getLineNumber();
         valueStartColumn = locator.getColumnNumber();
         if (Constants.DEPENDENCY.equals(qName)) {
-            isDependency = true;
-            dependencyStartLine = locator.getLineNumber();
-            dependencyStartColumn = locator.getColumnNumber() - (qName.length() + 2);
-            dependencyType = "";
+            if (!isPlugin) {
+                isDependency = true;
+                dependencyStartLine = locator.getLineNumber();
+                dependencyStartColumn = locator.getColumnNumber() - (qName.length() + 2);
+                dependencyType = "";
+            }
         } else if (Constants.PLUGIN.equals(qName)) {
             isPlugin = true;
             pluginArtifactId = "";

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -583,6 +583,7 @@ public class Constant {
     public static final String API_ARTIFACTS = "APIs";
     public static final String IS_MAIN_SEQUENCE = "isMainSequence";
     public static final String PROFILES = "profiles";
+    public static final String PROFILE = "profile";
     public static final String MAIN_SEQUENCE = "mainSequence";
     public static final String IS_SUPPORT_CATEGORIES = "isSupportCategories";
     public static final String MEMORY_CONFIG_KEY = "memoryConfigKey";

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/430/file.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/430/file.json
@@ -396,6 +396,7 @@
               "inputType": "combo",
               "comboValues": [
                 "NONE",
+                "Name",
                 "Size",
                 "Lastmodifiedtimestamp"
               ],

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/440/file.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/440/file.json
@@ -396,6 +396,7 @@
               "inputType": "combo",
               "comboValues": [
                 "NONE",
+                "Name",
                 "Size",
                 "Lastmodifiedtimestamp"
               ],


### PR DESCRIPTION
This PR adds support for the maven-car-deploy-plugin, enabling deployment of the generated CApps to a remote server.

Related issue: https://github.com/wso2/mi-vscode/issues/936