### PR TITLE
Handle integration project dependencies downloading and fetching resources

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -666,6 +666,13 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     }
 
     @Override
+    public CompletableFuture<String> loadDependentResources() {
+
+        String statusMessage = resourceFinder.loadDependentResources(projectUri);
+        return CompletableFuture.supplyAsync(() -> statusMessage);
+    }
+
+    @Override
     public CompletableFuture<ConnectorGeneratorResponse> generateConnector(ConnectorGenerateRequest connectorGenReq) {
         String filePath = null;
         try {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -668,8 +668,7 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     @Override
     public CompletableFuture<String> loadDependentResources() {
 
-        String statusMessage = resourceFinder.loadDependentResources(projectUri);
-        return CompletableFuture.supplyAsync(() -> statusMessage);
+        return CompletableFuture.supplyAsync(() -> resourceFinder.loadDependentResources(projectUri));
     }
 
     @Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -71,6 +71,7 @@ import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.SynapseCon
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.UISchemaRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.Constants;
 import org.eclipse.lemminx.customservice.synapse.parser.DeployPluginDetails;
+import org.eclipse.lemminx.customservice.synapse.parser.DependencyDownloadManager;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPage;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPageDetailsResponse;
 import org.eclipse.lemminx.customservice.synapse.parser.UpdateConfigRequest;
@@ -659,7 +660,7 @@ public class SynapseLanguageService implements ISynapseLanguageService {
 
     @Override
     public CompletableFuture<String> updateConnectorDependencies() {
-        String statusMessage = ConnectorDownloadManager.downloadConnectors(projectUri);
+        String statusMessage = DependencyDownloadManager.downloadDependencies(projectUri);
         updateConnectors();
         return CompletableFuture.supplyAsync(() -> statusMessage);
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
@@ -237,6 +237,9 @@ public interface ISynapseLanguageService {
     CompletableFuture<String> updateConnectorDependencies();
 
     @JsonRequest
+    CompletableFuture<String> loadDependentResources();
+
+    @JsonRequest
     CompletableFuture<TestConnectionResponse> testConnectorConnection(TestConnectionRequest request);
 
     @JsonRequest

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
@@ -14,20 +14,19 @@
 
 package org.eclipse.lemminx.customservice.synapse.parser;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
 import org.eclipse.lemminx.customservice.synapse.mediator.TryOutConstants;
 import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 import org.eclipse.lemminx.customservice.synapse.utils.Utils;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -37,17 +36,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
-import static org.eclipse.lemminx.customservice.synapse.parser.pom.PomParser.getPomDetails;
-import org.apache.commons.lang3.StringUtils;
+import static org.eclipse.lemminx.customservice.synapse.utils.Utils.copyFile;
+import static org.eclipse.lemminx.customservice.synapse.utils.Utils.getDependencyFromLocalRepo;
 
 public class ConnectorDownloadManager {
 
     private static final Logger LOGGER = Logger.getLogger(ConnectorDownloadManager.class.getName());
 
-    public static String downloadConnectors(String projectPath) {
+    public static List<String> downloadDependencies(String projectPath, List<DependencyDetails> dependencies) {
 
         String projectId = new File(projectPath).getName() + "_" + Utils.getHash(projectPath);
         File directory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI, Constant.CONNECTORS,
@@ -65,11 +61,9 @@ public class ConnectorDownloadManager {
             downloadDirectory.mkdirs();
         }
 
-        OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
-        getPomDetails(projectPath, pomDetailsResponse);
-        List<DependencyDetails> dependencies = pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
         deleteRemovedConnectors(downloadDirectory, dependencies, projectPath);
         List<String> failedDependencies = new ArrayList<>();
+
         for (DependencyDetails dependency : dependencies) {
             try {
                 File connector = Path.of(downloadDirectory.getAbsolutePath(),
@@ -78,7 +72,7 @@ public class ConnectorDownloadManager {
                 if (connector.exists() && connector.isFile()) {
                     LOGGER.log(Level.INFO, "Dependency already downloaded: " + connector.getName());
                 } else if ((existingArtifact = getDependencyFromLocalRepo(dependency.getGroupId(),
-                        dependency.getArtifact(), dependency.getVersion())) != null ) {
+                        dependency.getArtifact(), dependency.getVersion(), dependency.getType())) != null ) {
                     LOGGER.log(Level.INFO, "Copying dependency from local repository: " + connector.getName());
                     copyFile(existingArtifact, downloadDirectory);
                 } else {
@@ -92,11 +86,7 @@ public class ConnectorDownloadManager {
                 failedDependencies.add(failedDependency);
             }
         }
-        if (!failedDependencies.isEmpty()) {
-            LOGGER.log(Level.SEVERE, "Some connectors were not downloaded: " + String.join(", ", failedDependencies));
-            return "Some connectors were not downloaded: " + String.join(", ", failedDependencies);
-        }
-        return "Success";
+        return failedDependencies;
     }
 
     private static void deleteRemovedConnectors(File downloadDirectory, List<DependencyDetails> dependencies,
@@ -136,40 +126,6 @@ public class ConnectorDownloadManager {
     private static boolean isConnectorRemoved(File file, List<String> existingConnectors) {
 
         return file.isFile() && !existingConnectors.contains(file.getName().replace(Constant.ZIP_EXTENSION, ""));
-    }
-
-    private static File getDependencyFromLocalRepo(String groupId, String artifactId, String version) {
-
-        String localMavenRepo = Path.of(System.getProperty(Constant.USER_HOME),  Constant.M2,
-                Constant.REPOSITORY).toString();
-        String artifactPath = Path.of(localMavenRepo, groupId.replace(".", File.separator), artifactId,
-                version, artifactId + "-" + version + Constant.ZIP_EXTENSION).toString();
-        File artifactFile = new File(artifactPath);
-        if(artifactFile.exists()) {
-            LOGGER.log(Level.INFO, "Dependency found in the local repository: " + artifactId);
-            return artifactFile;
-        } else {
-            LOGGER.log(Level.INFO, "Dependency not found in the local repository: " + artifactId);
-            return null;
-        }
-    }
-
-    private static void copyFile(File source, File destinationFolder) throws IOException {
-
-        if (!destinationFolder.exists()) {
-            destinationFolder.mkdirs();
-        }
-        File destinationFile = Path.of(destinationFolder.getAbsolutePath(), source.getName()).toFile();
-        try (InputStream in = new FileInputStream(source); OutputStream out = new FileOutputStream(destinationFile)) {
-            byte[] buffer = new byte[1024];
-            int length;
-            while ((length = in.read(buffer)) > 0) {
-                out.write(buffer, 0, length);
-            }
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Error occurred while copying dependency from local repository: " + e.getMessage());
-            throw e;
-        }
     }
 
      /**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
@@ -74,7 +74,7 @@ public class ConnectorDownloadManager {
                 } else if ((existingArtifact = getDependencyFromLocalRepo(dependency.getGroupId(),
                         dependency.getArtifact(), dependency.getVersion(), dependency.getType())) != null ) {
                     LOGGER.log(Level.INFO, "Copying dependency from local repository: " + connector.getName());
-                    copyFile(existingArtifact, downloadDirectory);
+                    copyFile(existingArtifact.getPath(), downloadDirectory.getPath());
                 } else {
                     LOGGER.log(Level.INFO, "Downloading dependency: " + connector.getName());
                     Utils.downloadConnector(dependency.getGroupId(), dependency.getArtifact(),
@@ -204,7 +204,7 @@ public class ConnectorDownloadManager {
              // Try to find the driver in local Maven repository first
              File localDriverFile = getDriverFromLocalRepo(groupId, artifactId, version);
              if (localDriverFile != null) {
-                 copyFile(localDriverFile, driversDirectory);
+                 copyFile(localDriverFile.getPath(), driversDirectory.getPath());
                  return new File(driversDirectory, localDriverFile.getName()).getAbsolutePath();
              }
  

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/Constants.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/Constants.java
@@ -61,6 +61,7 @@ public class Constants {
     public static final String FULL_RANGE = "fullRange";
 
     public static final String ZIP = "zip";
+    public static final String CAR = "car";
     public static final String DOCKER_FILE_BASE_IMAGE = "dockerfile.base.image";
     public static final String CIPHER_TOOL_ENABLE = "ciphertool.enable";
     public static final String KEY_STORE_ALIAS = "keystore.alias";

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependenciesDetails.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependenciesDetails.java
@@ -19,10 +19,12 @@ import java.util.List;
 public class DependenciesDetails {
 
     private List<DependencyDetails> connectorDependencies;
+    private List<DependencyDetails> integrationProjectDependencies;
     private List<DependencyDetails> otherDependencies;
 
     DependenciesDetails() {
         connectorDependencies = new ArrayList<>();
+        integrationProjectDependencies = new ArrayList<>();
         otherDependencies = new ArrayList<>();
     }
 
@@ -32,6 +34,14 @@ public class DependenciesDetails {
 
     public void addConnectorDependencies(DependencyDetails dependencyDetails) {
         connectorDependencies.add(dependencyDetails);
+    }
+
+    public List<DependencyDetails> getIntegrationProjectDependencies() {
+        return integrationProjectDependencies;
+    }
+
+    public void addIntegrationProjectDependencies(DependencyDetails dependencyDetails) {
+        integrationProjectDependencies.add(dependencyDetails);
     }
 
     public void addOtherDependencies(DependencyDetails dependencyDetails) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
@@ -38,17 +38,24 @@ public class DependencyDownloadManager {
 
         OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
         getPomDetails(projectPath, pomDetailsResponse);
-        List<DependencyDetails> connectorDependencies = pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
-        List<DependencyDetails> integrationProjectDependencies = pomDetailsResponse.getDependenciesDetails().getIntegrationProjectDependencies();
-        List<String> failedConnectorDependencies = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
-        List<String> failedIntegrationProjectDependencies = IntegrationProjectDownloadManager.downloadDependencies(projectPath, integrationProjectDependencies);
+        List<DependencyDetails> connectorDependencies =
+                pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
+        List<DependencyDetails> integrationProjectDependencies =
+                pomDetailsResponse.getDependenciesDetails().getIntegrationProjectDependencies();
+        List<String> failedConnectorDependencies =
+                ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
+        List<String> failedIntegrationProjectDependencies =
+                IntegrationProjectDownloadManager.downloadDependencies(projectPath, integrationProjectDependencies);
         if (!failedConnectorDependencies.isEmpty()) {
-            LOGGER.log(Level.SEVERE, "Some connectors were not downloaded: " + String.join(", ", failedConnectorDependencies));
+            LOGGER.log(Level.SEVERE,
+                    "Some connectors were not downloaded: " + String.join(", ", failedConnectorDependencies));
             return "Some connectors were not downloaded: " + String.join(", ", failedConnectorDependencies);
         }
         if (!failedIntegrationProjectDependencies.isEmpty()) {
-            LOGGER.log(Level.SEVERE, "Some integration project dependencies were not downloaded: " + String.join(", ", failedIntegrationProjectDependencies));
-            return "Some integration project dependencies were not downloaded: " + String.join(", ", failedIntegrationProjectDependencies);
+            LOGGER.log(Level.SEVERE, "Some integration project dependencies were not downloaded: " +
+                    String.join(", ", failedIntegrationProjectDependencies));
+            return "Some integration project dependencies were not downloaded: " +
+                    String.join(", ", failedIntegrationProjectDependencies);
         }
         return "Success";
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.eclipse.lemminx.customservice.synapse.parser.pom.PomParser.getPomDetails;
+
+/**
+ * Manages the downloading of project dependencies defined in a Maven pom.xml file.
+ * Handles both connector and integration project dependencies, logging failures if any occur.
+ */
+public class DependencyDownloadManager {
+
+    private static final Logger LOGGER = Logger.getLogger(ConnectorDownloadManager.class.getName());
+
+    /**
+     * Downloads the dependencies specified in the pom.xml file of the given project.
+     *
+     * @param projectPath The path to the project directory containing the pom.xml file.
+     * @return A message indicating the success or failure of the download operation.
+     */
+    public static String downloadDependencies(String projectPath) {
+
+        OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
+        getPomDetails(projectPath, pomDetailsResponse);
+        List<DependencyDetails> connectorDependencies = pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
+        List<DependencyDetails> integrationProjectDependencies = pomDetailsResponse.getDependenciesDetails().getIntegrationProjectDependencies();
+        List<String> failedConnectorDependencies = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
+        List<String> failedIntegrationProjectDependencies = IntegrationProjectDownloadManager.downloadDependencies(projectPath, integrationProjectDependencies);
+        if (!failedConnectorDependencies.isEmpty()) {
+            LOGGER.log(Level.SEVERE, "Some connectors were not downloaded: " + String.join(", ", failedConnectorDependencies));
+            return "Some connectors were not downloaded: " + String.join(", ", failedConnectorDependencies);
+        }
+        if (!failedIntegrationProjectDependencies.isEmpty()) {
+            LOGGER.log(Level.SEVERE, "Some integration project dependencies were not downloaded: " + String.join(", ", failedIntegrationProjectDependencies));
+            return "Some integration project dependencies were not downloaded: " + String.join(", ", failedIntegrationProjectDependencies);
+        }
+        return "Success";
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -1,0 +1,210 @@
+package org.eclipse.lemminx.customservice.synapse.parser;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.lemminx.customservice.synapse.utils.Constant;
+import org.eclipse.lemminx.customservice.synapse.utils.Utils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.eclipse.lemminx.customservice.synapse.utils.Utils.copyFile;
+import static org.eclipse.lemminx.customservice.synapse.utils.Utils.getDependencyFromLocalRepo;
+
+/**
+ * Manages the downloading and extraction of integration project dependencies.
+ * <p>
+ * This class handles the recursive fetching of dependencies for integration projects,
+ * including downloading .car files, parsing their descriptor.xml files for additional
+ * dependencies, and managing the local storage of these files.
+ * </p>
+ */
+public class IntegrationProjectDownloadManager {
+
+    private static final Logger LOGGER = Logger.getLogger(ConnectorDownloadManager.class.getName());
+
+    /**
+     * Handles the downloading and extraction of integration project dependencies.
+     * <p>
+     * For each provided dependency, this method attempts to fetch the corresponding
+     * .car file, recursively resolves and downloads any additional dependencies
+     * specified in their descriptor.xml files, and manages local storage of these files.
+     * </p>
+     *
+     * @param projectPath  the file system path of the integration project
+     * @param dependencies the list of initial dependencies to process
+     * @return a list of dependency identifiers that failed to download or process
+     */
+    public static List<String> downloadDependencies(String projectPath, List<DependencyDetails> dependencies) {
+
+        String projectId = new File(projectPath).getName() + "_" + Utils.getHash(projectPath);
+        File directory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+                Constant.INTEGRATION_PROJECT_DEPENDENCIES, projectId).toFile();
+        File downloadDirectory = Path.of(directory.getAbsolutePath(), Constant.DOWNLOADED).toFile();
+        File extractDirectory = Path.of(directory.getAbsolutePath(), Constant.EXTRACTED).toFile();
+
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+        if (!extractDirectory.exists()) {
+            extractDirectory.mkdirs();
+        }
+        if (!downloadDirectory.exists()) {
+            downloadDirectory.mkdirs();
+        }
+
+        List<String> failedDependencies = new ArrayList<>();
+        Set<String> fetchedDependencies = new HashSet<>();
+
+        for (DependencyDetails dependency : dependencies) {
+            try {
+                fetchDependencyRecursively(dependency, downloadDirectory, fetchedDependencies);
+            } catch (Exception e) {
+                String failedDependency =
+                        dependency.getGroupId() + Constant.HYPHEN + dependency.getArtifact() + Constant.HYPHEN + dependency.getVersion();
+                LOGGER.log(Level.WARNING,
+                        "Error occurred while downloading dependency " + failedDependency + ": " + e.getMessage());
+                failedDependencies.add(failedDependency);
+            }
+        }
+        return failedDependencies;
+    }
+
+    /**
+     * Recursively fetches the specified dependency and its transitive dependencies.
+     * <p>
+     * Downloads the .car file for the given dependency, parses its descriptor.xml for additional
+     * dependencies, and recursively fetches those as well. Ensures that each dependency is only
+     * fetched once per invocation to avoid redundant downloads and infinite loops.
+     * </p>
+     *
+     * @param dependency          the dependency to fetch
+     * @param downloadDirectory   the directory to store downloaded .car files
+     * @param fetchedDependencies a set of dependency keys already fetched to prevent duplication
+     * @throws Exception if fetching or parsing fails
+     */
+    static void fetchDependencyRecursively(DependencyDetails dependency, File downloadDirectory,
+                                           Set<String> fetchedDependencies) throws Exception {
+
+        String dependencyKey = dependency.getGroupId() + ":" + dependency.getArtifact() + ":" + dependency.getVersion();
+        if (fetchedDependencies.contains(dependencyKey)) {
+            return; // Skip already fetched dependencies
+        }
+
+        fetchedDependencies.add(dependencyKey);
+
+        File carFile = fetchDependencyFile(dependency, downloadDirectory);
+        if (!carFile.exists()) {
+            throw new Exception("Failed to fetch .car file for dependency: " + dependencyKey);
+        }
+
+        // Parse the descriptor.xml to find transitive dependencies
+        List<DependencyDetails> transitiveDependencies = parseDescriptorFile(carFile);
+
+        // Recursively fetch transitive dependencies
+        for (DependencyDetails transitiveDependency : transitiveDependencies) {
+            fetchDependencyRecursively(transitiveDependency, downloadDirectory, fetchedDependencies);
+        }
+    }
+
+    /**
+     * Fetches the specified dependency file (.car) from the download directory or local repository.
+     * <p>
+     * If the dependency file already exists in the download directory, it is returned.
+     * Otherwise, attempts to copy it from the local repository. If not found locally,
+     * the method is prepared to handle remote downloads
+     * </p>
+     *
+     * @param dependency        the dependency details to fetch
+     * @param downloadDirectory the directory to store or locate the downloaded .car file
+     * @return the File object representing the dependency .car file
+     */
+    private static File fetchDependencyFile(DependencyDetails dependency, File downloadDirectory) {
+
+        File dependencyFile =
+                new File(downloadDirectory, dependency.getArtifact() + "-" + dependency.getVersion() + ".car");
+        if (dependencyFile.exists() && dependencyFile.isFile()) {
+            LOGGER.log(Level.INFO, "Dependency already downloaded: " + dependencyFile.getName());
+        } else {
+            File existingArtifact = getDependencyFromLocalRepo(dependency.getGroupId(),
+                    dependency.getArtifact(), dependency.getVersion(), dependency.getType());
+            if (existingArtifact != null) {
+                LOGGER.log(Level.INFO, "Copying dependency from local repository: " + dependencyFile.getName());
+                try {
+                    copyFile(existingArtifact, downloadDirectory);
+                } catch (IOException e) {
+                    String failedDependency =
+                            dependency.getGroupId() + "-" + dependency.getArtifact() + "-" + dependency.getVersion();
+                    LOGGER.log(Level.WARNING,
+                            "Error occurred while downloading dependency " + failedDependency + ": " + e.getMessage());
+                }
+            } else {
+                // if the dependency is not found in the local repository, download it from the remote repository
+            }
+        }
+        return dependencyFile;
+    }
+
+    /**
+     * Parses the `descriptor.xml` file inside the given .car file to extract dependency information.
+     * <p>
+     * Opens the .car file as a ZIP archive, locates the `descriptor.xml`, and reads dependency entries,
+     * converting them into a list of `DependencyDetails` objects.
+     * </p>
+     *
+     * @param carFile the .car file containing the `descriptor.xml`
+     * @return a list of `DependencyDetails` parsed from the descriptor
+     * @throws Exception if the file cannot be read or parsed, or if `descriptor.xml` is missing
+     */
+    private static List<DependencyDetails> parseDescriptorFile(File carFile) throws Exception {
+
+        List<DependencyDetails> dependencies = new ArrayList<>();
+        try (ZipFile zipFile = new ZipFile(carFile)) {
+            ZipEntry descriptorEntry = zipFile.getEntry("descriptor.xml");
+            if (descriptorEntry == null) {
+                throw new Exception("descriptor.xml not found in .car file: " + carFile.getName());
+            }
+
+            InputStream inputStream = zipFile.getInputStream(descriptorEntry);
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document document = builder.parse(inputStream);
+            document.getDocumentElement().normalize();
+
+            NodeList dependencyNodes = document.getElementsByTagName("dependency");
+            for (int i = 0; i < dependencyNodes.getLength(); i++) {
+                Element dependencyElement = (Element) dependencyNodes.item(i);
+                String groupId = dependencyElement.getAttribute("groupId");
+                String artifactId = dependencyElement.getAttribute("artifactId");
+                String version = dependencyElement.getAttribute("version");
+                String type = dependencyElement.getAttribute("type");
+
+                if (StringUtils.isNotEmpty(groupId) && StringUtils.isNotEmpty(artifactId)
+                        && StringUtils.isNotEmpty(version) && StringUtils.isNotEmpty(type)) {
+                    DependencyDetails dependency = new DependencyDetails();
+                    dependency.setGroupId(groupId);
+                    dependency.setArtifact(artifactId);
+                    dependency.setVersion(version);
+                    dependency.setType(type);
+                    dependencies.add(dependency);
+                }
+            }
+        }
+        return dependencies;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -154,7 +154,7 @@ public class IntegrationProjectDownloadManager {
                             "Error occurred while downloading dependency " + failedDependency + ": " + e.getMessage());
                 }
             } else {
-                // if the dependency is not found in the local repository, download it from the remote repository
+                // TODO: Download the dependency from the remote repository if not found in the local repository
             }
         }
         return dependencyFile;
@@ -177,7 +177,8 @@ public class IntegrationProjectDownloadManager {
         try (ZipFile zipFile = new ZipFile(carFile)) {
             ZipEntry descriptorEntry = zipFile.getEntry("descriptor.xml");
             if (descriptorEntry == null) {
-                throw new Exception("descriptor.xml not found in .car file: " + carFile.getName());
+                LOGGER.log(Level.INFO, "descriptor.xml not found in .car file: " + carFile.getName());
+                return dependencies; // Return empty list if descriptor.xml is missing
             }
 
             InputStream inputStream = zipFile.getInputStream(descriptorEntry);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -146,7 +146,7 @@ public class IntegrationProjectDownloadManager {
             if (existingArtifact != null) {
                 LOGGER.log(Level.INFO, "Copying dependency from local repository: " + dependencyFile.getName());
                 try {
-                    copyFile(existingArtifact, downloadDirectory);
+                    copyFile(existingArtifact.getPath(), downloadDirectory.getPath());
                 } catch (IOException e) {
                     String failedDependency =
                             dependency.getGroupId() + "-" + dependency.getArtifact() + "-" + dependency.getVersion();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
 package org.eclipse.lemminx.customservice.synapse.parser;
 
 import org.apache.commons.lang3.StringUtils;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/pom/PluginHandler.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/pom/PluginHandler.java
@@ -222,6 +222,8 @@ public class PluginHandler extends DefaultHandler {
                 dependency.setRange(getRange(dependencyStartLine, dependencyStartColumn, valueEndLine, valueEndColumn));
                 if (Constants.ZIP.equals(dependencyType)) {
                     pomDetailsResponse.getDependenciesDetails().addConnectorDependencies(dependency);
+                } else if (Constants.CAR.equals(dependencyType)) {
+                    pomDetailsResponse.getDependenciesDetails().addIntegrationProjectDependencies(dependency);
                 } else {
                     pomDetailsResponse.getDependenciesDetails().addOtherDependencies(dependency);
                 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
@@ -120,7 +120,7 @@ public abstract class AbstractResourceFinder {
         Path projectDependenciesTempDir = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
                 Constant.INTEGRATION_PROJECT_DEPENDENCIES);
         // Pattern to match the project dependency dir in cached dir
-        String projectDependencyDirPattern = "^" + projectName + "_[a-zA-Z0-9]+$";
+        final String projectDependencyDirPattern = "^" + projectName + "_[a-zA-Z0-9]+$";
 
         try (var projectDirs = list(projectDependenciesTempDir)) {
             // Find the dependency directory for the current project

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
@@ -42,6 +42,10 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.isDirectory;
+import static java.nio.file.Files.list;
+
 public abstract class AbstractResourceFinder {
 
     private static final Logger LOGGER = Logger.getLogger(AbstractResourceFinder.class.getName());
@@ -53,6 +57,7 @@ public abstract class AbstractResourceFinder {
 
     // This has the xml tag mapping for each artifact type
     private static final Map<String, String> typeToXmlTagMap = new HashMap<>();
+    protected Map<String, ResourceResponse> dependentResourcesMap = new HashMap<>();
 
     static {
 
@@ -76,6 +81,124 @@ public abstract class AbstractResourceFinder {
         typeToXmlTagMap.put("xslt", "xsl:stylesheet");
         typeToXmlTagMap.put("xsd", "xs:schema");
         typeToXmlTagMap.put("wsdl", "wsdl:definitions");
+    }
+
+    public void initDependentResourcesMap() {
+        dependentResourcesMap.put("endpoint", new ResourceResponse());
+        dependentResourcesMap.put("sequence", new ResourceResponse());
+        dependentResourcesMap.put("messageStore", new ResourceResponse());
+        dependentResourcesMap.put("messageProcessor", new ResourceResponse());
+        dependentResourcesMap.put("endpointTemplate", new ResourceResponse());
+        dependentResourcesMap.put("sequenceTemplate", new ResourceResponse());
+        dependentResourcesMap.put("localEntry", new ResourceResponse());
+        dependentResourcesMap.put("inbound-endpoint", new ResourceResponse());
+        dependentResourcesMap.put("dataService", new ResourceResponse());
+        dependentResourcesMap.put("dataSource", new ResourceResponse());
+        dependentResourcesMap.put("ws_policy", new ResourceResponse());
+        dependentResourcesMap.put("smooksConfig", new ResourceResponse());
+        dependentResourcesMap.put("xsl", new ResourceResponse());
+        dependentResourcesMap.put("xslt", new ResourceResponse());
+        dependentResourcesMap.put("xsd", new ResourceResponse());
+        dependentResourcesMap.put("wsdl", new ResourceResponse());
+    }
+
+    /**
+     * Loads dependent resources for the given project path.
+     * <p>
+     * This method initializes the dependent resources map and attempts to locate
+     * the dependencies directory for the specified project. If found, it iterates
+     * through each dependent project, finds resources of each type, and merges them
+     * into the dependent resources map.
+     *
+     * @param projectPath the absolute path to the project whose dependencies are to be loaded
+     * @throws RuntimeException if an I/O error occurs while accessing the dependencies
+     */
+    public String loadDependentResources(String projectPath) {
+
+        initDependentResourcesMap();
+        String projectName = Path.of(projectPath).getFileName().toString();
+        Path projectDependenciesTempDir = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+                Constant.INTEGRATION_PROJECT_DEPENDENCIES);
+        // Pattern to match the project dependency dir in cached dir
+        String projectDependencyDirPattern = "^" + projectName + "_[a-zA-Z0-9]+$";
+
+        try (var projectDirs = list(projectDependenciesTempDir)) {
+            // Find the dependency directory for the current project
+            Path projectDependencyDir = projectDirs
+                    .filter(path -> {
+                        return path.getFileName().toString().matches(projectDependencyDirPattern) && isDirectory(path);
+                    })
+                    .findFirst()
+                    .orElse(null);
+            if (projectDependencyDir != null) {
+                // Each dependency CAR will be extracted and stored as an integration project in the EXTRACTED directory
+                Path extractedDir = projectDependencyDir.resolve(Constant.EXTRACTED);
+                if (exists(extractedDir) && isDirectory(extractedDir)) {
+                    Map<String, ResourceResponse> dependentResourcesMap = getDependentResourcesMap();
+                    try (var dependentProjects = list(extractedDir)) {
+                        // Iterate over each dependent project directory
+                        for (Path dependentProject : dependentProjects.toArray(Path[]::new)) {
+                            if (isDirectory(dependentProject)) {
+                                // For each resource type, find and merge resources from the dependent project
+                                for (Map.Entry<String, ResourceResponse> entry : dependentResourcesMap.entrySet()) {
+                                    String type = entry.getKey();
+                                    ResourceResponse dependentResources = entry.getValue();
+
+                                    RequestedResource requestedResource = new RequestedResource(type, true);
+                                    ResourceResponse resources =
+                                            findResources(dependentProject.toString(), List.of(requestedResource));
+                                    mergeResourceResponses(dependentResources, resources);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.warning("Failed to load dependent resources for project: " + projectPath + ". Error: " + e.getMessage());
+            return "Failed to load dependent resources for project: " + projectPath;
+        }
+        return "Dependent resources loaded successfully for project: " + projectPath;
+    }
+
+    public Map<String, ResourceResponse> getDependentResourcesMap() {
+
+        return dependentResourcesMap;
+    }
+
+    /**
+     * Merges the resources and registry resources from two {@link ResourceResponse} objects.
+     * <p>
+     * If both responses are non-null, their resource lists and registry resource lists are combined to {@code response1}.
+     * If {@code response1} is null, a new {@link ResourceResponse} is created and populated with the resources from {@code response2}.
+     *
+     * @param response1 the target {@link ResourceResponse} to merge into (may be null)
+     * @param response2 the source {@link ResourceResponse} to merge from (may be null)
+     */
+    protected void mergeResourceResponses(ResourceResponse response1, ResourceResponse response2) {
+
+        if (response1 != null && response2 != null) {
+            List<Resource> resources = response1.getResources();
+            if (resources == null) {
+                resources = new ArrayList<>();
+            }
+            if (response2.getResources() != null) {
+                resources.addAll(response2.getResources());
+            }
+            response1.setResources(resources);
+            List<Resource> registryResources = response1.getRegistryResources();
+            if (registryResources == null) {
+                registryResources = new ArrayList<>();
+            }
+            if (response2.getRegistryResources() != null) {
+                registryResources.addAll(response2.getRegistryResources());
+            }
+            response1.setRegistryResources(registryResources);
+        } else if (response1 == null) {
+            response1 = new ResourceResponse();
+            response1.setResources(response2.getResources());
+            response1.setRegistryResources(response2.getRegistryResources());
+        }
     }
 
     public ResourceResponse getAvailableResources(String uri, Either<String, List<RequestedResource>> resourceTypes) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/NewProjectResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/NewProjectResourceFinder.java
@@ -21,6 +21,7 @@ import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 public class NewProjectResourceFinder extends AbstractResourceFinder {
 
@@ -32,6 +33,14 @@ public class NewProjectResourceFinder extends AbstractResourceFinder {
         findArtifactResources(projectPath, types, response);
         findRegistryResources(projectPath, types, response);
 
+        Map<String, ResourceResponse> dependentResourcesMap = getDependentResourcesMap();
+        for (RequestedResource type : types) {
+            String resourceType = type.getType();
+            if (dependentResourcesMap.containsKey(resourceType)) {
+                ResourceResponse dependentResponse = dependentResourcesMap.get(resourceType);
+                mergeResourceResponses(response, dependentResponse);
+            }
+        }
         return response;
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -410,6 +410,7 @@ public class Constant {
     public static final String PROJECT = "project";
     public static final String CONNECTOR = "connector";
     public static final String DOT = ".";
+    public static final String HYPHEN = "-";
     public static final String XML = "xml";
     public static final String LOCAL_ENTRIES = "local-entries";
     public static final CharSequence GOV_REGISTRY_PREFIX = "gov:";
@@ -423,6 +424,7 @@ public class Constant {
     public static final String CALL_TEMPLATE = "call-template";
     public static final String STORE = "store";
     public static final String DEPENDENCY = "dependency";
+    public static final String INTEGRATION_PROJECT_DEPENDENCIES = "integration-project-dependencies";
     public static final String COMPONENT = "component";
     public static final String INCLUDE = "include";
     public static final String KEY_EXPRESSION = "key-expression";
@@ -521,6 +523,7 @@ public class Constant {
     public static final String NAMESPACES = "namespaces";
     public static final String CONNECTION_NAME = "connectionName";
     public static final String ZIP_EXTENSION = ".zip";
+    public static final String CAR_EXTENSION = ".car";
     public static final String JAR_EXTENSION = ".jar";
     public static final String ZIP_EXTENSION_NO_DOT = "zip";
     public static final String JAR_EXTENSION_NO_DOT = "jar";

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -1425,31 +1425,6 @@ public class Utils {
         }
     }
 
-    /**
-     * Copies a file to the specified destination folder.
-     *
-     * @param source the source file to copy
-     * @param destinationFolder the target folder where the file will be copied
-     * @throws IOException if an I/O error occurs during copying
-     */
-    public static void copyFile(File source, File destinationFolder) throws IOException {
-
-        if (!destinationFolder.exists()) {
-            destinationFolder.mkdirs();
-        }
-        File destinationFile = Path.of(destinationFolder.getAbsolutePath(), source.getName()).toFile();
-        try (InputStream in = new FileInputStream(source); OutputStream out = new FileOutputStream(destinationFile)) {
-            byte[] buffer = new byte[1024];
-            int length;
-            while ((length = in.read(buffer)) > 0) {
-                out.write(buffer, 0, length);
-            }
-        } catch (Exception e) {
-            logger.log(Level.SEVERE, "Error occurred while copying dependency from local repository: " + e.getMessage());
-            throw e;
-        }
-    }
-
     public static boolean isValidProject(String projectRoot) {
 
         if (StringUtils.isEmpty(projectRoot)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -52,6 +52,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -1396,6 +1397,56 @@ public class Utils {
             if (connection != null) {
                 connection.disconnect();
             }
+        }
+    }
+
+    /**
+     * Retrieves a dependency file from the local Maven repository.
+     *
+     * @param groupId    the group ID of the dependency
+     * @param artifactId the artifact ID of the dependency
+     * @param version    the version of the dependency
+     * @param type       the file type (e.g., jar, zip)
+     * @return the dependency file if it exists, otherwise null
+     */
+    public static File getDependencyFromLocalRepo(String groupId, String artifactId, String version, String type) {
+
+        String localMavenRepo = Path.of(System.getProperty(Constant.USER_HOME),  Constant.M2,
+                Constant.REPOSITORY).toString();
+        String artifactPath = Path.of(localMavenRepo, groupId.replace(Constant.DOT, File.separator), artifactId,
+                version, artifactId + Constant.HYPHEN + version + Constant.DOT + type).toString();
+        File artifactFile = new File(artifactPath);
+        if(artifactFile.exists()) {
+            logger.log(Level.INFO, "Dependency found in the local repository: " + artifactId);
+            return artifactFile;
+        } else {
+            logger.log(Level.INFO, "Dependency not found in the local repository: " + artifactId);
+            return null;
+        }
+    }
+
+    /**
+     * Copies a file to the specified destination folder.
+     *
+     * @param source the source file to copy
+     * @param destinationFolder the target folder where the file will be copied
+     * @throws IOException if an I/O error occurs during copying
+     */
+    public static void copyFile(File source, File destinationFolder) throws IOException {
+
+        if (!destinationFolder.exists()) {
+            destinationFolder.mkdirs();
+        }
+        File destinationFile = Path.of(destinationFolder.getAbsolutePath(), source.getName()).toFile();
+        try (InputStream in = new FileInputStream(source); OutputStream out = new FileOutputStream(destinationFile)) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = in.read(buffer)) > 0) {
+                out.write(buffer, 0, length);
+            }
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error occurred while copying dependency from local repository: " + e.getMessage());
+            throw e;
         }
     }
 


### PR DESCRIPTION
## Purpose
As we allow to add a project as a dependency to another project. we need to download that dependency when we download other dependencies. Also there should be a way to load the resources that are inside those dependency as well. Hence this will introduce the following changes:
* update the current connector download process to have a single dependency download process
* add downloading integration project (.car) dependencies to the cached dir
* add a way to fetch resources from the dependent projects