### PR TITLE
Fix connector extracting issue in unit tests

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/test/UnitTestFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/syntaxTree/factory/test/UnitTestFactory.java
@@ -205,8 +205,10 @@ public class UnitTestFactory extends AbstractFactory {
         if (children != null && !children.isEmpty()) {
             List<STNode> connectorResourceList = new ArrayList<>();
             for (DOMNode child : children) {
-                STNode connectorResource = createSimpleNode((DOMElement) child);
-                connectorResourceList.add(connectorResource);
+                if (Constant.CONNECTOR_RESOURCE.equalsIgnoreCase(child.getLocalName())) {
+                    STNode connectorResource = createSimpleNode((DOMElement) child);
+                    connectorResourceList.add(connectorResource);
+                }
             }
             connectorResources.setConnectorResources(connectorResourceList.toArray(
                     new STNode[connectorResourceList.size()]));

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -466,6 +466,7 @@ public class Constant {
     public static final String REGISTRY_RESOURCES = "registry-resources";
     public static final String REGISTRY_RESOURCE = "registry-resource";
     public static final String CONNECTOR_RESOURCES = "connector-resources";
+    public static final String CONNECTOR_RESOURCE = "connector-resource";
     public static final String FILE_NAME = "file-name";
     public static final String ARTIFACT = "artifact";
     public static final String ARTIFACT_XML = "artifact.xml";


### PR DESCRIPTION
This PR will fix the issue of not being able to render the unit test explorer when the connector-resources tag in the unit test configuration has no child elements.