### PR TITLE
Add needLastMediator Logic in handling Helper Pane

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/expression/ExpressionHelperProvider.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/expression/ExpressionHelperProvider.java
@@ -76,6 +76,9 @@ public class ExpressionHelperProvider {
         if (!ExpressionCompletionUtils.isValidRequest(param)) {
             return getBasicHelperData();
         }
+        if (param.getNeedLastMediator()) {
+            return getLastMediatorHelperData(param);
+        }
         try {
             boolean isNewMediator = isNewMediator(param);
             String payload =
@@ -106,11 +109,11 @@ public class ExpressionHelperProvider {
             return getBasicHelperData();
         }
         try {
-            Path documentTruePath = Paths.get(new URI(param.getDocumentUri()));
+            Path documentTruePath = Path.of(Utils.getAbsolutePath(param.getDocumentUri()));
             Position position =
                     ExpressionCompletionUtils.getLastMediatorPosition(documentTruePath.toString(), param.getPosition());
             return getExpressionHelperData(new ExpressionParam(documentTruePath.toString(), position));
-        } catch (IOException | URISyntaxException e) {
+        } catch (IOException e) {
             return getBasicHelperData();
         }
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/expression/pojo/ExpressionParam.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/expression/pojo/ExpressionParam.java
@@ -22,6 +22,7 @@ public class ExpressionParam {
     private Position position;
     private String expression;
     private int offset;
+	private boolean needLastMediator;
 
     public ExpressionParam(String expression, int offset) {
 
@@ -43,6 +44,13 @@ public class ExpressionParam {
         this.position = position;
     }
 
+    public ExpressionParam(String documentUri, Position position, boolean needLastMediator) {
+
+        this.documentUri = documentUri;
+        this.position = position;
+        this.needLastMediator = needLastMediator;
+    }
+
     public String getDocumentUri() {
 
         return documentUri;
@@ -62,4 +70,8 @@ public class ExpressionParam {
 
         return offset;
     }
+
+	public boolean getNeedLastMediator(){
+		return needLastMediator;
+	}
 }


### PR DESCRIPTION
Add needLastMediator Logic in handling Helper Pane to facilitate synapse expression support in MI Unit Test Framework. This would ensure that 'position' parameter is not required to obtain helper pane data when the call is made from the Test Suite and would instead check the whole file by pointing to the last mediator.