### PR TITLE
Update loading dependent resources process

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
@@ -124,6 +124,13 @@ public abstract class AbstractResourceFinder {
         Map<String, List<String>> duplicates = new HashMap<>();
         Map<String, ResourceResponse> tempResourcesMap = new HashMap<>();
         Map<String, List<String>> artifactNameToProjects = new HashMap<>();
+
+        // Collect main project artifact names
+        for (String type : dependentResourcesMap.keySet()) {
+            ResourceResponse mainResources = findResources(projectPath, type);
+            addArtifactNamesToProjects(mainResources, projectName, artifactNameToProjects);
+        }
+
         try (var projectDirs = list(projectDependenciesTempDir)) {
             // Find the dependency directory for the current project
             Path projectDependencyDir = projectDirs


### PR DESCRIPTION
## Purpose
This will introduce the following changes:
- update the common `dependentResourcesMap` after loading resources from all dependent projects 
- when capturing same named artifacts availability consider the available artifacts in the current project as well 
