### PR TITLE
Update dependent integration projects fetching and loading 

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -37,6 +37,8 @@ import java.util.zip.ZipFile;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import static org.eclipse.lemminx.customservice.synapse.utils.Constant.DOT;
+import static org.eclipse.lemminx.customservice.synapse.utils.Constant.HYPHEN;
 import static org.eclipse.lemminx.customservice.synapse.utils.Utils.copyFile;
 import static org.eclipse.lemminx.customservice.synapse.utils.Utils.getDependencyFromLocalRepo;
 
@@ -90,7 +92,7 @@ public class IntegrationProjectDownloadManager {
                 fetchDependencyRecursively(dependency, downloadDirectory, fetchedDependencies);
             } catch (Exception e) {
                 String failedDependency =
-                        dependency.getGroupId() + Constant.HYPHEN + dependency.getArtifact() + Constant.HYPHEN + dependency.getVersion();
+                        dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN + dependency.getVersion();
                 LOGGER.log(Level.WARNING,
                         "Error occurred while downloading dependency " + failedDependency + ": " + e.getMessage());
                 failedDependencies.add(failedDependency);
@@ -150,8 +152,9 @@ public class IntegrationProjectDownloadManager {
      */
     private static File fetchDependencyFile(DependencyDetails dependency, File downloadDirectory) {
 
-        File dependencyFile =
-                new File(downloadDirectory, dependency.getArtifact() + "-" + dependency.getVersion() + ".car");
+        File dependencyFile = new File(downloadDirectory,
+                dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN + dependency.getVersion() + DOT +
+                        dependency.getType());
         if (dependencyFile.exists() && dependencyFile.isFile()) {
             LOGGER.log(Level.INFO, "Dependency already downloaded: " + dependencyFile.getName());
         } else {
@@ -160,10 +163,12 @@ public class IntegrationProjectDownloadManager {
             if (existingArtifact != null) {
                 LOGGER.log(Level.INFO, "Copying dependency from local repository: " + dependencyFile.getName());
                 try {
-                    copyFile(existingArtifact.getPath(), downloadDirectory.getPath());
+                    String newFileName = dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN +
+                            dependency.getVersion() + DOT + dependency.getType();
+                    copyFile(existingArtifact.getPath(), downloadDirectory.getPath(), newFileName);
                 } catch (IOException e) {
                     String failedDependency =
-                            dependency.getGroupId() + "-" + dependency.getArtifact() + "-" + dependency.getVersion();
+                            dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN + dependency.getVersion();
                     LOGGER.log(Level.WARNING,
                             "Error occurred while downloading dependency " + failedDependency + ": " + e.getMessage());
                 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
@@ -131,6 +131,7 @@ public abstract class AbstractResourceFinder {
 
         Map<String, List<String>> duplicates = new HashMap<>();
         Map<String, ResourceResponse> tempResourcesMap = new HashMap<>();
+        // Used to identify any duplicate artifacts across projects
         Map<String, List<String>> artifactNameToProjects = new HashMap<>();
 
         // Collect main project artifacts

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
@@ -117,7 +117,7 @@ public abstract class AbstractResourceFinder {
 
         initDependentResourcesMap();
         String projectName = new File(projectPath).getName();
-        Path projectDependencyDir = findProjectDependencyDir(projectName);
+        Path projectDependencyDir = findProjectDependencyDir(projectPath);
         if (projectDependencyDir == null) {
             LOGGER.warning("No project dependency directory found for project: " + projectPath);
             return "No dependent integration projects found";
@@ -186,28 +186,28 @@ public abstract class AbstractResourceFinder {
     }
 
     /**
-     * Finds the integration project dependency directory for a given project name.
+     * Finds the dependency directory for a given project path.
      * <p>
-     * Searches for a directory matching the pattern "{projectName}_[a-zA-Z0-9]+" and returns its path if found.
+     * This method constructs the expected dependency directory path using the user's home directory,
+     * WSO2 MI constants, and a hash of the project path.
      *
-     * @param projectName the name of the project whose dependency directory is to be found
-     * @return the path to the project dependency directory, or null if not found or an I/O error occurs
+     * @param projectPath the absolute path to the project
+     * @return the dependency directory as a Path if it exists, or null if not found
      */
-    private Path findProjectDependencyDir(String projectName) {
+    private Path findProjectDependencyDir(String projectPath) {
 
-        Path projectDependenciesTempDir = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
-                Constant.INTEGRATION_PROJECT_DEPENDENCIES);
-        // Pattern to match the project dependency dir in cached dir
-        final String projectDependencyDirPattern = "^" + projectName + "_[a-zA-Z0-9]+$";
-        try (var projectDirs = list(projectDependenciesTempDir)) {
-            return projectDirs
-                    .filter(path -> path.getFileName().toString().matches(projectDependencyDirPattern) &&
-                            isDirectory(path))
-                    .findFirst()
-                    .orElse(null);
-        } catch (IOException e) {
-            return null;
+        Path dependenciesDir = Path.of(
+                System.getProperty(Constant.USER_HOME),
+                Constant.WSO2_MI,
+                Constant.INTEGRATION_PROJECT_DEPENDENCIES
+        );
+        String projectName = new File(projectPath).getName();
+        String hashedPath = Utils.getHash(projectPath);
+        Path expectedDir = dependenciesDir.resolve(projectName + Constant.UNDERSCORE + hashedPath);
+        if (exists(expectedDir) && isDirectory(expectedDir)) {
+            return expectedDir;
         }
+        return null;
     }
 
     /**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -411,6 +411,7 @@ public class Constant {
     public static final String CONNECTOR = "connector";
     public static final String DOT = ".";
     public static final String HYPHEN = "-";
+    public static final String UNDERSCORE = "_";
     public static final String XML = "xml";
     public static final String LOCAL_ENTRIES = "local-entries";
     public static final CharSequence GOV_REGISTRY_PREFIX = "gov:";


### PR DESCRIPTION
## Purpose
Implement the following changes:
- Identify the project referenced during artifact loading from integration project dependencies using both the project name and the hashed project path.
- Store the retrieved CAR applications for each dependency under a unique dependency ID (`groupId`-`artifactId`-`version`.`type`).
