### PR TITLE
[4.0.0] Load connectors from integration project dependencies and improve dependency download flow

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -703,9 +703,11 @@ public class SynapseLanguageService implements ISynapseLanguageService {
 
     @Override
     public CompletableFuture<String> refetchIntegrationProjectDependencies() {
-        log.info("Refetching integration project dependencies for project: " + projectUri);
-        String statusMessage = DependencyDownloadManager.refetchIntegrationProjectDependencies(projectUri);
-        return CompletableFuture.supplyAsync(() -> statusMessage);
+        
+		log.info("Refetching integration project dependencies for project: " + projectUri);
+        return CompletableFuture.supplyAsync(() -> {
+			return DependencyDownloadManager.refetchIntegrationProjectDependencies(projectUri);
+		});
     }
 
     @Override
@@ -717,9 +719,11 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     @Override
     public CompletableFuture<String> loadDependentResources() {
 
-        String result = resourceFinder.loadDependentResources(projectUri);
-        updateConnectors();
-        return CompletableFuture.supplyAsync(() -> result);
+        return CompletableFuture.supplyAsync(() -> {
+			String result = resourceFinder.loadDependentResources(projectUri);
+        	updateConnectors();
+			return result;
+		});
     }
 
     @Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -710,7 +710,9 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     @Override
     public CompletableFuture<String> loadDependentResources() {
 
-        return CompletableFuture.supplyAsync(() -> resourceFinder.loadDependentResources(projectUri));
+        String result = resourceFinder.loadDependentResources(projectUri);
+        updateConnectors();
+        return CompletableFuture.supplyAsync(() -> result);
     }
 
     @Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -703,6 +703,7 @@ public class SynapseLanguageService implements ISynapseLanguageService {
 
     @Override
     public CompletableFuture<String> refetchIntegrationProjectDependencies() {
+        log.info("Refetching integration project dependencies for project: " + projectUri);
         String statusMessage = DependencyDownloadManager.refetchIntegrationProjectDependencies(projectUri);
         return CompletableFuture.supplyAsync(() -> statusMessage);
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -702,6 +702,12 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     }
 
     @Override
+    public CompletableFuture<String> refetchIntegrationProjectDependencies() {
+        String statusMessage = DependencyDownloadManager.refetchIntegrationProjectDependencies(projectUri);
+        return CompletableFuture.supplyAsync(() -> statusMessage);
+    }
+
+    @Override
     public CompletableFuture<DependencyStatusResponse> getDependencyStatusList() {
 
         return CompletableFuture.supplyAsync(() -> DependencyDownloadManager.getDependencyStatusList(projectUri));

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
@@ -253,6 +253,9 @@ public interface ISynapseLanguageService {
     CompletableFuture<String> updateConnectorDependencies();
 
     @JsonRequest
+    CompletableFuture<String> refetchIntegrationProjectDependencies();
+
+    @JsonRequest
     CompletableFuture<String> loadDependentResources();
 
     @JsonRequest

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
@@ -24,6 +24,7 @@ import org.eclipse.lemminx.customservice.synapse.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
@@ -37,6 +38,7 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
 
     private static final Logger log = Logger.getLogger(NewProjectConnectorLoader.class.getName());
     private String projectId;
+    protected final List<String> baseConnectorsZipFolderPaths = new ArrayList<>();
 
     public NewProjectConnectorLoader(SynapseLanguageClientAPI languageClient, ConnectorHolder connectorHolder,
                                      InboundConnectorHolder inboundConnectorHolder) {
@@ -129,11 +131,62 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
     }
 
     @Override
+    public void loadConnector() {
+
+        connectorsZipFolderPath.clear();
+        connectorsZipFolderPath.addAll(baseConnectorsZipFolderPaths);
+        addDependencyProjectConnectorPaths();
+        super.loadConnector();
+    }
+
+    @Override
     protected void setConnectorsZipFolderPath(String projectRoot) {
 
-        connectorsZipFolderPath.add(Path.of(projectRoot, Constant.SRC, Constant.MAIN, Constant.WSO2MI,
-                Constant.RESOURCES, Constant.CONNECTORS).toString());
         projectId = new File(projectRoot).getName() + "_" + Utils.getHash(projectRoot);
-        connectorsZipFolderPath.add(getConnnectorDownloadPath().toString());
+        baseConnectorsZipFolderPaths.add(Path.of(projectRoot, Constant.SRC, Constant.MAIN, Constant.WSO2MI,
+                Constant.RESOURCES, Constant.CONNECTORS).toString());
+        baseConnectorsZipFolderPaths.add(getConnnectorDownloadPath().toString());
+        connectorsZipFolderPath.addAll(baseConnectorsZipFolderPaths);
+    }
+
+    /**
+     * Scans the extracted dependency project directories and adds their connector paths
+     * to the connector zip folder paths list.
+     */
+    private void addDependencyProjectConnectorPaths() {
+
+        Path extractedDir = findProjectDependencyExtractedDir();
+        if (extractedDir == null) {
+            return;
+        }
+        File[] dependentProjects = extractedDir.toFile().listFiles(File::isDirectory);
+        if (dependentProjects == null) {
+            return;
+        }
+        for (File dependentProject : dependentProjects) {
+            Path connectorPath = dependentProject.toPath()
+                    .resolve(Constant.SRC).resolve(Constant.MAIN).resolve(Constant.WSO2MI)
+                    .resolve(Constant.RESOURCES).resolve(Constant.CONNECTORS);
+            if (connectorPath.toFile().isDirectory()) {
+                connectorsZipFolderPath.add(connectorPath.toString());
+            }
+        }
+    }
+
+    /**
+     * Returns the extracted directory for the current project's integration project dependencies,
+     * or null if it does not exist.
+     */
+    private Path findProjectDependencyExtractedDir() {
+
+        if (projectId == null) {
+            return null;
+        }
+        Path expectedDir = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+                Constant.INTEGRATION_PROJECT_DEPENDENCIES, projectId, Constant.EXTRACTED);
+        if (expectedDir.toFile().isDirectory()) {
+            return expectedDir;
+        }
+        return null;
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
@@ -46,10 +46,15 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
         super(languageClient, connectorHolder, inboundConnectorHolder);
     }
 
+    protected String getUserHome() {
+
+        return System.getProperty(Constant.USER_HOME);
+    }
+
     @Override
     protected File getConnectorExtractFolder() {
 
-        String tempFolderPath = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+        String tempFolderPath = Path.of(getUserHome(), Constant.WSO2_MI,
                 Constant.CONNECTORS, projectId, Constant.EXTRACTED).toString();
         File tempFolder = new File(tempFolderPath);
         return tempFolder;
@@ -111,7 +116,7 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
                                 .resolve(Constant.UI_SCHEMA_JSON).toFile());
                         String fileName = Utils.getJsonObject(schema).get(Constant.NAME).getAsString() + Constant.JSON_FILE_EXT;
                         String projectFolderName = connectorExtractFolder.getParentFile().getName();
-                        File schemaToRemove = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+                        File schemaToRemove = Path.of(getUserHome(), Constant.WSO2_MI,
                                 Constant.INBOUND_CONNECTORS).resolve(projectFolderName).resolve(fileName).toFile();
                         FileUtils.delete(schemaToRemove);
                     }
@@ -126,16 +131,17 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
 
     private Path getConnnectorDownloadPath() {
 
-        return Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+        return Path.of(getUserHome(), Constant.WSO2_MI,
                 Constant.CONNECTORS, projectId, Constant.DOWNLOADED);
     }
 
     @Override
     public void loadConnector() {
 
-        connectorsZipFolderPath.clear();
+		connectorsZipFolderPath.clear();
         connectorsZipFolderPath.addAll(baseConnectorsZipFolderPaths);
         addDependencyProjectConnectorPaths();
+		log.info("Loading connectors from " + connectorsZipFolderPath.size() + " paths for project: " + projectId);
         super.loadConnector();
     }
 
@@ -169,6 +175,7 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
                     .resolve(Constant.RESOURCES).resolve(Constant.CONNECTORS);
             if (connectorPath.toFile().isDirectory()) {
                 connectorsZipFolderPath.add(connectorPath.toString());
+                log.info("Added connector path from dependency project: " + connectorPath);
             }
         }
     }
@@ -182,7 +189,7 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
         if (projectId == null) {
             return null;
         }
-        Path expectedDir = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+        Path expectedDir = Path.of(getUserHome(), Constant.WSO2_MI,
                 Constant.INTEGRATION_PROJECT_DEPENDENCIES, projectId, Constant.EXTRACTED);
         if (expectedDir.toFile().isDirectory()) {
             return expectedDir;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
@@ -15,6 +15,7 @@
 package org.eclipse.lemminx.customservice.synapse.connectors;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lemminx.customservice.SynapseLanguageClientAPI;
 import org.eclipse.lemminx.customservice.synapse.inbound.conector.InboundConnectorHolder;
 import org.eclipse.lemminx.customservice.synapse.mediator.TryOutConstants;
@@ -186,7 +187,7 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
      */
     private Path findProjectDependencyExtractedDir() {
 
-        if (projectId == null) {
+        if (StringUtils.isEmpty(projectId)) {
             return null;
         }
         Path expectedDir = Path.of(getUserHome(), Constant.WSO2_MI,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
@@ -42,6 +42,7 @@ public class DependencyDownloadManager {
      */
     public static String downloadDependencies(String projectPath) {
 
+        LOGGER.log(Level.INFO, "Starting dependency download for project: " + projectPath);
         OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
         getPomDetails(projectPath, pomDetailsResponse);
         List<DependencyDetails> connectorDependencies =
@@ -88,6 +89,7 @@ public class DependencyDownloadManager {
      */
     public static String refetchIntegrationProjectDependencies(String projectPath) {
 
+        LOGGER.log(Level.INFO, "Starting integration project dependencies re-fetch for project: " + projectPath);
         OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
         getPomDetails(projectPath, pomDetailsResponse);
         List<DependencyDetails> integrationProjectDependencies =

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
@@ -106,6 +106,76 @@ public class DependencyDownloadManager {
         return "Success";
     }
 
+    /**
+     * Clears the Downloaded and Extracted directories and re-fetches all integration project
+     * dependencies from scratch for the given project.
+     *
+     * @param projectPath The path to the project directory containing the pom.xml file.
+     * @return A message indicating the success or failure of the re-fetch operation.
+     */
+    public static String refetchIntegrationProjectDependencies(String projectPath) {
+
+        OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
+        getPomDetails(projectPath, pomDetailsResponse);
+        List<DependencyDetails> integrationProjectDependencies =
+                pomDetailsResponse.getDependenciesDetails().getIntegrationProjectDependencies();
+        Node isVersionedDeployment = pomDetailsResponse.getBuildDetails().getVersionedDeployment();
+        boolean isVersionedDeploymentEnabled = isVersionedDeployment != null ?
+                Boolean.parseBoolean(isVersionedDeployment.getValue()) : false;
+        DependencyDownloadResult result =
+                IntegrationProjectDownloadManager.refetchDependencies(projectPath, integrationProjectDependencies,
+                        isVersionedDeploymentEnabled);
+
+        return buildResultMessage(result, projectPath);
+    }
+
+    /**
+     * Builds a human-readable result message from a {@link DependencyDownloadResult},
+     * logging and concatenating each category of failure. Returns {@code "Success"} if
+     * there were no failures.
+     */
+    private static String buildResultMessage(DependencyDownloadResult result, String projectPath) {
+
+        StringBuilder errorMessage = new StringBuilder();
+        boolean hasErrors = false;
+
+        if (!result.getFailedDependencies().isEmpty()) {
+            String projectError = "Following integration project dependencies were unavailable: " +
+                    String.join(", ", result.getFailedDependencies());
+            LOGGER.log(Level.SEVERE, projectError);
+            errorMessage.append(projectError);
+            hasErrors = true;
+        }
+
+        if (!result.getNoDescriptorDependencies().isEmpty()) {
+            String descriptorError = "Following dependencies do not contain the descriptor file: " +
+                    String.join(", ", result.getNoDescriptorDependencies());
+            LOGGER.log(Level.SEVERE, descriptorError);
+            if (hasErrors) {
+                errorMessage.append(". ");
+            }
+            errorMessage.append(descriptorError);
+            hasErrors = true;
+        }
+
+        if (!result.getVersioningTypeMismatchDependencies().isEmpty()) {
+            String versioningTypeError = "Versioned deployment status is different from the dependent project: " +
+                    String.join(", ", result.getVersioningTypeMismatchDependencies());
+            LOGGER.log(Level.SEVERE, versioningTypeError);
+            if (hasErrors) {
+                errorMessage.append(". ");
+            }
+            errorMessage.append(versioningTypeError);
+            hasErrors = true;
+        }
+
+        if (hasErrors) {
+            return errorMessage.toString();
+        }
+        LOGGER.log(Level.INFO, "Integration project dependencies downloaded successfully for project: " + projectPath);
+        return "Success";
+    }
+
     public static DependencyStatusResponse getDependencyStatusList(String projectPath) {
         OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
         getPomDetails(projectPath, pomDetailsResponse);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
@@ -42,8 +42,6 @@ public class DependencyDownloadManager {
      */
     public static String downloadDependencies(String projectPath) {
 
-        StringBuilder errorMessage = new StringBuilder();
-        boolean hasErrors = false;
         OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
         getPomDetails(projectPath, pomDetailsResponse);
         List<DependencyDetails> connectorDependencies =
@@ -55,51 +53,26 @@ public class DependencyDownloadManager {
         Node isVersionedDeployment = pomDetailsResponse.getBuildDetails().getVersionedDeployment();
         boolean isVersionedDeploymentEnabled = isVersionedDeployment != null ?
                 Boolean.parseBoolean(isVersionedDeployment.getValue()) : false;
-        DependencyDownloadResult failedIntegrationProjectDependencies =
+        DependencyDownloadResult integrationProjectResult =
                 IntegrationProjectDownloadManager.downloadDependencies(projectPath, integrationProjectDependencies,
                         isVersionedDeploymentEnabled);
 
+        StringBuilder errorMessage = new StringBuilder();
         if (!failedConnectorDependencies.isEmpty()) {
             String connectorError = "Some connectors were not downloaded: " + String.join(", ", failedConnectorDependencies);
             LOGGER.log(Level.SEVERE, connectorError);
             errorMessage.append(connectorError);
-            hasErrors = true;
         }
 
-        if (!failedIntegrationProjectDependencies.getFailedDependencies().isEmpty()) {
-            String projectError = "Following integration project dependencies were unavailable: " +
-                    String.join(", ", failedIntegrationProjectDependencies.getFailedDependencies());
-            LOGGER.log(Level.SEVERE, projectError);
-            if (hasErrors) {
+        String integrationProjectsErrorMessage = buildIntegrationProjectsErrorMessage(integrationProjectResult);
+        if (!integrationProjectsErrorMessage.isEmpty()) {
+            if (errorMessage.length() > 0) {
                 errorMessage.append(". ");
             }
-            errorMessage.append(projectError);
-            hasErrors = true;
+            errorMessage.append(integrationProjectsErrorMessage);
         }
 
-        if (!failedIntegrationProjectDependencies.getNoDescriptorDependencies().isEmpty()) {
-            String descriptorError = "Following dependencies do not contain the descriptor file: " +
-                    String.join(", ", failedIntegrationProjectDependencies.getNoDescriptorDependencies());
-            LOGGER.log(Level.SEVERE, descriptorError);
-            if (hasErrors) {
-                errorMessage.append(". ");
-            }
-            errorMessage.append(descriptorError);
-            hasErrors = true;
-        }
-
-        if (!failedIntegrationProjectDependencies.getVersioningTypeMismatchDependencies().isEmpty()) {
-            String versioningTypeError = "Versioned deployment status is different from the dependent project: " +
-                    String.join(", ", failedIntegrationProjectDependencies.getVersioningTypeMismatchDependencies());
-            LOGGER.log(Level.SEVERE, versioningTypeError);
-            if (hasErrors) {
-                errorMessage.append(". ");
-            }
-            errorMessage.append(versioningTypeError);
-            hasErrors = true;
-        }
-
-        if (hasErrors) {
+        if (errorMessage.length() > 0) {
             return errorMessage.toString();
         }
         LOGGER.log(Level.INFO, "All dependencies downloaded successfully for project: " + projectPath);
@@ -126,54 +99,51 @@ public class DependencyDownloadManager {
                 IntegrationProjectDownloadManager.refetchDependencies(projectPath, integrationProjectDependencies,
                         isVersionedDeploymentEnabled);
 
-        return buildResultMessage(result, projectPath);
+        String errorMessage = buildIntegrationProjectsErrorMessage(result);
+        if (errorMessage.isEmpty()) {
+            LOGGER.log(Level.INFO, "Integration project dependencies downloaded successfully for project: " + projectPath);
+            return "Success";
+        }
+        return errorMessage;
     }
 
     /**
-     * Builds a human-readable result message from a {@link DependencyDownloadResult},
-     * logging and concatenating each category of failure. Returns {@code "Success"} if
+     * Builds a human-readable error string from a {@link DependencyDownloadResult},
+     * logging and concatenating each category of failure. Returns an empty string if
      * there were no failures.
      */
-    private static String buildResultMessage(DependencyDownloadResult result, String projectPath) {
+    private static String buildIntegrationProjectsErrorMessage(DependencyDownloadResult result) {
 
         StringBuilder errorMessage = new StringBuilder();
-        boolean hasErrors = false;
 
         if (!result.getFailedDependencies().isEmpty()) {
             String projectError = "Following integration project dependencies were unavailable: " +
                     String.join(", ", result.getFailedDependencies());
             LOGGER.log(Level.SEVERE, projectError);
             errorMessage.append(projectError);
-            hasErrors = true;
         }
 
         if (!result.getNoDescriptorDependencies().isEmpty()) {
             String descriptorError = "Following dependencies do not contain the descriptor file: " +
                     String.join(", ", result.getNoDescriptorDependencies());
             LOGGER.log(Level.SEVERE, descriptorError);
-            if (hasErrors) {
+            if (errorMessage.length() > 0) {
                 errorMessage.append(". ");
             }
             errorMessage.append(descriptorError);
-            hasErrors = true;
         }
 
         if (!result.getVersioningTypeMismatchDependencies().isEmpty()) {
             String versioningTypeError = "Versioned deployment status is different from the dependent project: " +
                     String.join(", ", result.getVersioningTypeMismatchDependencies());
             LOGGER.log(Level.SEVERE, versioningTypeError);
-            if (hasErrors) {
+            if (errorMessage.length() > 0) {
                 errorMessage.append(". ");
             }
             errorMessage.append(versioningTypeError);
-            hasErrors = true;
         }
 
-        if (hasErrors) {
-            return errorMessage.toString();
-        }
-        LOGGER.log(Level.INFO, "Integration project dependencies downloaded successfully for project: " + projectPath);
-        return "Success";
+        return errorMessage.toString();
     }
 
     public static DependencyStatusResponse getDependencyStatusList(String projectPath) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -60,6 +60,45 @@ public class IntegrationProjectDownloadManager {
     private static final Logger LOGGER = Logger.getLogger(ConnectorDownloadManager.class.getName());
 
     /**
+     * Clears the Downloaded and Extracted directories for the given project and re-fetches
+     * all integration project dependencies from scratch.
+     * <p>
+     * This is a hard-refresh: all previously cached files are discarded before downloading,
+     * so every dependency is fetched fresh regardless of what was present before.
+     * </p>
+     *
+     * @param projectPath  the file system path of the integration project
+     * @param dependencies the list of dependencies to fetch
+     * @param isVersionedDeploymentEnabled indicates if versioned deployment is enabled in the parent project
+     * @return a result object containing any dependencies that failed to download or process
+     */
+    public static DependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
+                                                               boolean isVersionedDeploymentEnabled) {
+
+        String projectId = new File(projectPath).getName() + UNDERSCORE + Utils.getHash(projectPath);
+        File directory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+                Constant.INTEGRATION_PROJECT_DEPENDENCIES, projectId).toFile();
+        File downloadDirectory = Path.of(directory.getAbsolutePath(), Constant.DOWNLOADED).toFile();
+        File extractDirectory = Path.of(directory.getAbsolutePath(), Constant.EXTRACTED).toFile();
+
+        try {
+            if (downloadDirectory.exists()) {
+                Utils.deleteDirectory(downloadDirectory.toPath());
+                LOGGER.log(Level.INFO, "Cleared Downloaded directory for project: " + projectId);
+            }
+            if (extractDirectory.exists()) {
+                Utils.deleteDirectory(extractDirectory.toPath());
+                LOGGER.log(Level.INFO, "Cleared Extracted directory for project: " + projectId);
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to clear dependency directories for project " + projectId
+                    + ": " + e.getMessage());
+        }
+
+        return downloadDependencies(projectPath, dependencies, isVersionedDeploymentEnabled);
+    }
+
+    /**
      * Handles the downloading and extraction of integration project dependencies.
      * <p>
      * For each provided dependency, this method attempts to fetch the corresponding

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -75,6 +75,7 @@ public class IntegrationProjectDownloadManager {
     public static DependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                                boolean isVersionedDeploymentEnabled) {
 
+        LOGGER.log(Level.INFO, "Starting hard refresh of dependencies for project: " + new File(projectPath).getName());
         return refetchDependencies(projectPath, dependencies, isVersionedDeploymentEnabled,
                 Path.of(System.getProperty(Constant.USER_HOME)));
     }
@@ -153,6 +154,8 @@ public class IntegrationProjectDownloadManager {
 
         for (DependencyDetails dependency : dependencies) {
             try {
+                LOGGER.log(Level.INFO, "Processing dependency: " + dependency.getGroupId() + HYPHEN
+                        + dependency.getArtifact() + HYPHEN + dependency.getVersion());
                 fetchDependencyRecursively(dependency, downloadDirectory, fetchedDependencies,
                         isVersionedDeploymentEnabled, userHome);
             } catch (NoDescriptorException e) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -75,9 +75,17 @@ public class IntegrationProjectDownloadManager {
     public static DependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                                boolean isVersionedDeploymentEnabled) {
 
+        return refetchDependencies(projectPath, dependencies, isVersionedDeploymentEnabled,
+                Path.of(System.getProperty(Constant.USER_HOME)));
+    }
+
+    public static DependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
+                                                        boolean isVersionedDeploymentEnabled, Path userHome) {
+
         String projectId = new File(projectPath).getName() + UNDERSCORE + Utils.getHash(projectPath);
-        File directory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
-                Constant.INTEGRATION_PROJECT_DEPENDENCIES, projectId).toFile();
+        File directory = userHome.resolve(Constant.WSO2_MI)
+                .resolve(Constant.INTEGRATION_PROJECT_DEPENDENCIES)
+                .resolve(projectId).toFile();
         File downloadDirectory = Path.of(directory.getAbsolutePath(), Constant.DOWNLOADED).toFile();
         File extractDirectory = Path.of(directory.getAbsolutePath(), Constant.EXTRACTED).toFile();
 
@@ -95,7 +103,7 @@ public class IntegrationProjectDownloadManager {
                     + ": " + e.getMessage());
         }
 
-        return downloadDependencies(projectPath, dependencies, isVersionedDeploymentEnabled);
+        return downloadDependencies(projectPath, dependencies, isVersionedDeploymentEnabled, userHome);
     }
 
     /**
@@ -114,9 +122,17 @@ public class IntegrationProjectDownloadManager {
     public static DependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                                 boolean isVersionedDeploymentEnabled) {
 
+        return downloadDependencies(projectPath, dependencies, isVersionedDeploymentEnabled,
+                Path.of(System.getProperty(Constant.USER_HOME)));
+    }
+
+    public static DependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies,
+                                                         boolean isVersionedDeploymentEnabled, Path userHome) {
+
         String projectId = new File(projectPath).getName() + UNDERSCORE + Utils.getHash(projectPath);
-        File directory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
-                Constant.INTEGRATION_PROJECT_DEPENDENCIES, projectId).toFile();
+        File directory = userHome.resolve(Constant.WSO2_MI)
+                .resolve(Constant.INTEGRATION_PROJECT_DEPENDENCIES)
+                .resolve(projectId).toFile();
         File downloadDirectory = Path.of(directory.getAbsolutePath(), Constant.DOWNLOADED).toFile();
         File extractDirectory = Path.of(directory.getAbsolutePath(), Constant.EXTRACTED).toFile();
 
@@ -138,7 +154,7 @@ public class IntegrationProjectDownloadManager {
         for (DependencyDetails dependency : dependencies) {
             try {
                 fetchDependencyRecursively(dependency, downloadDirectory, fetchedDependencies,
-                        isVersionedDeploymentEnabled);
+                        isVersionedDeploymentEnabled, userHome);
             } catch (NoDescriptorException e) {
                 String failedDependency =
                         dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN + dependency.getVersion();
@@ -255,7 +271,8 @@ public class IntegrationProjectDownloadManager {
      * @throws Exception if fetching or parsing fails
      */
     static void fetchDependencyRecursively(DependencyDetails dependency, File downloadDirectory,
-                                           Set<String> fetchedDependencies, boolean isVersionedDeploymentEnabled)
+                                           Set<String> fetchedDependencies, boolean isVersionedDeploymentEnabled,
+                                           Path userHome)
             throws Exception {
 
         // Colon separator avoids key collisions as colons are invalid in Maven coordinates.
@@ -276,7 +293,7 @@ public class IntegrationProjectDownloadManager {
             LOGGER.log(Level.INFO, "Dependency already in Downloaded directory: " + existingFile.getName());
             carFile = existingFile;
         } else {
-            carFile = fetchDependencyFile(dependency, downloadDirectory);
+            carFile = fetchDependencyFile(dependency, downloadDirectory, userHome);
             if (!carFile.exists()) {
                 throw new Exception("Failed to fetch .car file for dependency: " + dependencyKey);
             }
@@ -294,7 +311,7 @@ public class IntegrationProjectDownloadManager {
         // Recursively fetch transitive dependencies
         for (DependencyDetails transitiveDependency : transitiveDependencies) {
             fetchDependencyRecursively(transitiveDependency, downloadDirectory,
-                    fetchedDependencies, isVersionedDeploymentEnabled);
+                    fetchedDependencies, isVersionedDeploymentEnabled, userHome);
         }
     }
 
@@ -331,7 +348,7 @@ public class IntegrationProjectDownloadManager {
      * @param downloadDirectory the directory to store or locate the downloaded .car file
      * @return the File object representing the dependency .car file
      */
-    private static File fetchDependencyFile(DependencyDetails dependency, File downloadDirectory) {
+    private static File fetchDependencyFile(DependencyDetails dependency, File downloadDirectory, Path userHome) {
 
         File dependencyFile = new File(downloadDirectory,
                 dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN + dependency.getVersion() + DOT +
@@ -340,7 +357,7 @@ public class IntegrationProjectDownloadManager {
             LOGGER.log(Level.INFO, "Dependency already downloaded: " + dependencyFile.getName());
         } else {
             File existingArtifact = getDependencyFromLocalRepo(dependency.getGroupId(),
-                    dependency.getArtifact(), dependency.getVersion(), dependency.getType());
+                    dependency.getArtifact(), dependency.getVersion(), dependency.getType(), userHome);
             if (existingArtifact != null) {
                 LOGGER.log(Level.INFO, "Copying dependency from local repository: " + dependencyFile.getName());
                 try {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -38,8 +38,12 @@ import java.util.zip.ZipFile;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import static org.eclipse.lemminx.customservice.synapse.utils.Constant.CAR_EXTENSION;
+import static org.eclipse.lemminx.customservice.synapse.utils.Constant.COLON;
 import static org.eclipse.lemminx.customservice.synapse.utils.Constant.DOT;
 import static org.eclipse.lemminx.customservice.synapse.utils.Constant.HYPHEN;
+import static org.eclipse.lemminx.customservice.synapse.utils.Constant.UNDERSCORE;
+import static org.eclipse.lemminx.customservice.synapse.utils.Constant.ZIP_EXTENSION;
 import static org.eclipse.lemminx.customservice.synapse.utils.Utils.copyFile;
 import static org.eclipse.lemminx.customservice.synapse.utils.Utils.getDependencyFromLocalRepo;
 
@@ -71,7 +75,7 @@ public class IntegrationProjectDownloadManager {
     public static DependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                                 boolean isVersionedDeploymentEnabled) {
 
-        String projectId = new File(projectPath).getName() + "_" + Utils.getHash(projectPath);
+        String projectId = new File(projectPath).getName() + UNDERSCORE + Utils.getHash(projectPath);
         File directory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
                 Constant.INTEGRATION_PROJECT_DEPENDENCIES, projectId).toFile();
         File downloadDirectory = Path.of(directory.getAbsolutePath(), Constant.DOWNLOADED).toFile();
@@ -94,7 +98,8 @@ public class IntegrationProjectDownloadManager {
 
         for (DependencyDetails dependency : dependencies) {
             try {
-                fetchDependencyRecursively(dependency, downloadDirectory, fetchedDependencies, isVersionedDeploymentEnabled);
+                fetchDependencyRecursively(dependency, downloadDirectory, fetchedDependencies,
+                        isVersionedDeploymentEnabled);
             } catch (NoDescriptorException e) {
                 String failedDependency =
                         dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN + dependency.getVersion();
@@ -116,15 +121,92 @@ public class IntegrationProjectDownloadManager {
                 failedDependencies.add(failedDependency);
             }
         }
+
+        Set<String> expectedBaseNames = buildExpectedBaseNames(fetchedDependencies);
+        deleteObsoleteDownloadedFiles(downloadDirectory, expectedBaseNames);
+        deleteObsoleteExtractedDirs(extractDirectory, expectedBaseNames);
+
         return new DependencyDownloadResult(failedDependencies, noDescriptorDependencies, versioningMismatchDependencies);
+    }
+
+    /**
+     * Converts a set of dependency keys ({@code groupId:artifactId:version}) into the
+     * set of base names ({@code groupId-artifactId-version}) used as file/directory names
+     * in the Downloaded and Extracted directories.
+     */
+    private static Set<String> buildExpectedBaseNames(Set<String> fetchedDependencies) {
+
+        Set<String> expectedBaseNames = new HashSet<>();
+        for (String key : fetchedDependencies) {
+            String[] parts = key.split(COLON);
+            if (parts.length >= 3) {
+                expectedBaseNames.add(parts[0] + HYPHEN + parts[1] + HYPHEN + parts[2]);
+            }
+        }
+        return expectedBaseNames;
+    }
+
+    /**
+     * Deletes files from the Downloaded directory whose base name (filename without
+     * the {@code .car} or {@code .zip} extension) is not present in {@code expectedBaseNames}.
+     */
+    private static void deleteObsoleteDownloadedFiles(File downloadDirectory, Set<String> expectedBaseNames) {
+
+        File[] downloadedFiles = downloadDirectory.listFiles(File::isFile);
+        if (downloadedFiles == null) {
+            return;
+        }
+        for (File file : downloadedFiles) {
+            String name = file.getName();
+            String baseName;
+            if (name.endsWith(CAR_EXTENSION)) {
+                baseName = name.substring(0, name.length() - 4);
+            } else if (name.endsWith(ZIP_EXTENSION)) {
+                baseName = name.substring(0, name.length() - 4);
+            } else {
+                continue;
+            }
+            if (!expectedBaseNames.contains(baseName)) {
+                LOGGER.log(Level.INFO, "Deleting obsolete downloaded file: " + name);
+                if (!file.delete()) {
+                    LOGGER.log(Level.WARNING, "Failed to delete obsolete downloaded file: " + name);
+                }
+            }
+        }
+    }
+
+    /**
+     * Deletes directories from the Extracted directory whose name is not present
+     * in {@code expectedBaseNames}.
+     */
+    private static void deleteObsoleteExtractedDirs(File extractDirectory, Set<String> expectedBaseNames) {
+
+        File[] extractedDirs = extractDirectory.listFiles(File::isDirectory);
+        if (extractedDirs == null) {
+            return;
+        }
+        for (File dir : extractedDirs) {
+            if (!expectedBaseNames.contains(dir.getName())) {
+                LOGGER.log(Level.INFO, "Deleting obsolete extracted dependency directory: " + dir.getName());
+                try {
+                    Utils.deleteDirectory(dir.toPath());
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING,
+                            "Failed to delete obsolete extracted directory " + dir.getName() + ": " + e.getMessage());
+                }
+            }
+        }
     }
 
     /**
      * Recursively fetches the specified dependency and its transitive dependencies.
      * <p>
-     * Downloads the .car file for the given dependency, parses its descriptor.xml for additional
-     * dependencies, and recursively fetches those as well. Ensures that each dependency is only
-     * fetched once per invocation to avoid redundant downloads and infinite loops.
+     * If the dependency is already present in the Downloaded directory (as a {@code .car} or
+     * {@code .zip}), the download is skipped and the existing file is used directly for descriptor
+     * parsing. Otherwise the file is fetched from the local Maven repository. After obtaining the
+     * file, its {@code descriptor.xml} is parsed for transitive dependencies which are then fetched
+     * recursively. Each dependency is processed at most once per invocation to prevent duplicate
+     * downloads and infinite loops.
      * </p>
      *
      * @param dependency          the dependency to fetch
@@ -137,16 +219,28 @@ public class IntegrationProjectDownloadManager {
                                            Set<String> fetchedDependencies, boolean isVersionedDeploymentEnabled)
             throws Exception {
 
-        String dependencyKey = dependency.getGroupId() + ":" + dependency.getArtifact() + ":" + dependency.getVersion();
+        // Colon separator avoids key collisions as colons are invalid in Maven coordinates.
+        String dependencyKey = dependency.getGroupId() + COLON + dependency.getArtifact() + COLON + dependency.getVersion();
         if (fetchedDependencies.contains(dependencyKey)) {
             return; // Skip already fetched dependencies
         }
 
         fetchedDependencies.add(dependencyKey);
 
-        File carFile = fetchDependencyFile(dependency, downloadDirectory);
-        if (!carFile.exists()) {
-            throw new Exception("Failed to fetch .car file for dependency: " + dependencyKey);
+        String carBaseName = dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN + dependency.getVersion();
+
+        // If the dependency is already present in the Downloaded directory (as .car or .zip),
+        // skip fetching and use the existing file directly for descriptor parsing.
+        File existingFile = findInDownloadDirectory(carBaseName, downloadDirectory);
+        File carFile;
+        if (existingFile != null) {
+            LOGGER.log(Level.INFO, "Dependency already in Downloaded directory: " + existingFile.getName());
+            carFile = existingFile;
+        } else {
+            carFile = fetchDependencyFile(dependency, downloadDirectory);
+            if (!carFile.exists()) {
+                throw new Exception("Failed to fetch .car file for dependency: " + dependencyKey);
+            }
         }
 
         // Parse the descriptor.xml to find transitive dependencies
@@ -160,8 +254,30 @@ public class IntegrationProjectDownloadManager {
 
         // Recursively fetch transitive dependencies
         for (DependencyDetails transitiveDependency : transitiveDependencies) {
-            fetchDependencyRecursively(transitiveDependency, downloadDirectory, fetchedDependencies, isVersionedDeploymentEnabled);
+            fetchDependencyRecursively(transitiveDependency, downloadDirectory,
+                    fetchedDependencies, isVersionedDeploymentEnabled);
         }
+    }
+
+    /**
+     * Looks for an existing file for the given dependency base name in the Downloaded directory.
+     * Checks for both the pre-extraction ({@code .car}) and post-extraction ({@code .zip}) variants.
+     *
+     * @param carBaseName       the base name ({@code groupId-artifactId-version}) to look up
+     * @param downloadDirectory the directory to search in
+     * @return the existing file, or {@code null} if neither variant is present
+     */
+    private static File findInDownloadDirectory(String carBaseName, File downloadDirectory) {
+
+        File carFile = new File(downloadDirectory, carBaseName + CAR_EXTENSION);
+        if (carFile.exists() && carFile.isFile()) {
+            return carFile;
+        }
+        File zipFile = new File(downloadDirectory, carBaseName + ZIP_EXTENSION);
+        if (zipFile.exists() && zipFile.isFile()) {
+            return zipFile;
+        }
+        return null;
     }
 
     /**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Constant.java
@@ -416,6 +416,7 @@ public class Constant {
     public static final String PROJECT = "project";
     public static final String CONNECTOR = "connector";
     public static final String DOT = ".";
+    public static final String COLON = ":";
     public static final String HYPHEN = "-";
     public static final String UNDERSCORE = "_";
     public static final String XML = "xml";

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -1523,8 +1523,14 @@ public class Utils {
      */
     public static File getDependencyFromLocalRepo(String groupId, String artifactId, String version, String type) {
 
-        String localMavenRepo = Path.of(System.getProperty(Constant.USER_HOME),  Constant.M2,
-                Constant.REPOSITORY).toString();
+        return getDependencyFromLocalRepo(groupId, artifactId, version, type,
+                Path.of(System.getProperty(Constant.USER_HOME)));
+    }
+
+    public static File getDependencyFromLocalRepo(String groupId, String artifactId, String version, String type,
+                                           Path userHome) {
+
+        String localMavenRepo = userHome.resolve(Constant.M2).resolve(Constant.REPOSITORY).toString();
         String artifactPath = Path.of(localMavenRepo, groupId.replace(Constant.DOT, File.separator), artifactId,
                 version, artifactId + Constant.HYPHEN + version + Constant.DOT + type).toString();
         File artifactFile = new File(artifactPath);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/MockConnectorLoader.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/MockConnectorLoader.java
@@ -53,5 +53,6 @@ public class MockConnectorLoader extends NewProjectConnectorLoader {
 
         String connectorZipPath = tempPath.resolve("connectors").toString();
         connectorsZipFolderPath.add(connectorZipPath);
+        baseConnectorsZipFolderPaths.add(connectorZipPath);
     }
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
@@ -19,6 +19,7 @@ import org.eclipse.lemminx.customservice.SynapseLanguageClientAPI;
 import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
 import org.eclipse.lemminx.customservice.synapse.connectors.NewProjectConnectorLoader;
 import org.eclipse.lemminx.customservice.synapse.inbound.conector.InboundConnectorHolder;
+import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 import org.eclipse.lemminx.customservice.synapse.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -171,6 +172,7 @@ public class NewDependentProjectConnectorLoaderTest {
         Files.createDirectories(extractedDir.resolve("dep-project-B").resolve("src").resolve("main"));
 
         loader.init(projectRoot.toString());
+        loader.loadConnector();
 
         List<String> paths = loader.getConnectorsZipFolderPaths();
         assertEquals(2, paths.size(),

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.synapse.connector.loader;
+
+import org.eclipse.lemminx.MockXMLLanguageClient;
+import org.eclipse.lemminx.customservice.SynapseLanguageClientAPI;
+import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
+import org.eclipse.lemminx.customservice.synapse.connectors.NewProjectConnectorLoader;
+import org.eclipse.lemminx.customservice.synapse.inbound.conector.InboundConnectorHolder;
+import org.eclipse.lemminx.customservice.synapse.utils.Constant;
+import org.eclipse.lemminx.customservice.synapse.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.eclipse.lemminx.synapse.TestUtils.getResourceFilePath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for loading connectors from dependency integration projects
+ * in {@link NewProjectConnectorLoader}.
+ */
+public class NewDependentProjectConnectorLoaderTest {
+
+    /**
+     * Minimal subclass that exposes {@code connectorsZipFolderPath} for assertions
+     * and skips the copy-to-project step which is irrelevant for dependency loading.
+     */
+    static class TestableLoader extends NewProjectConnectorLoader {
+
+        TestableLoader(SynapseLanguageClientAPI client, ConnectorHolder holder,
+                       InboundConnectorHolder inboundHolder) {
+            super(client, holder, inboundHolder);
+        }
+
+        List<String> getConnectorsZipFolderPaths() {
+            return connectorsZipFolderPath;
+        }
+
+        @Override
+        protected void copyToProjectIfNeeded(List<File> connectorZips) {
+            // no-op — not relevant for dependency loading tests
+        }
+    }
+
+    private static final String CONNECTOR_RELATIVE_PATH =
+            Constant.SRC + File.separator + Constant.MAIN + File.separator +
+            Constant.WSO2MI + File.separator + Constant.RESOURCES + File.separator + Constant.CONNECTORS;
+
+    private String originalUserHome;
+    private Path tempHome;
+    private Path projectRoot;
+    private TestableLoader loader;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+
+        originalUserHome = System.getProperty(Constant.USER_HOME);
+
+        tempHome = Files.createTempDirectory("mi-test-home-");
+        System.setProperty(Constant.USER_HOME, tempHome.toString());
+
+        // Create a minimal valid project root (requires pom.xml and src/)
+        projectRoot = Files.createTempDirectory("mi-test-project-");
+        Files.createFile(projectRoot.resolve("pom.xml"));
+        Files.createDirectory(projectRoot.resolve("src"));
+
+        ConnectorHolder connectorHolder = ConnectorHolder.getInstance();
+        connectorHolder.clearConnectors();
+        InboundConnectorHolder inboundConnectorHolder = new InboundConnectorHolder();
+        SynapseLanguageClientAPI languageClient = new MockXMLLanguageClient();
+
+        loader = new TestableLoader(languageClient, connectorHolder, inboundConnectorHolder);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+
+        System.setProperty(Constant.USER_HOME, originalUserHome);
+        deleteRecursively(tempHome);
+        deleteRecursively(projectRoot);
+    }
+
+    /**
+     * When there is no dependency extracted directory at all,
+     * only the two base connector paths (project source and downloaded) should be present.
+     */
+    @Test
+    public void testNoDependencyExtractedDir_onlyBasePathsAdded() throws Exception {
+
+        loader.init(projectRoot.toString());
+
+        List<String> paths = loader.getConnectorsZipFolderPaths();
+        assertEquals(2, paths.size(),
+                "Only the two base paths should be present when no dependency dir exists");
+    }
+
+    /**
+     * When the dependency extracted directory exists but contains no sub-directories,
+     * no additional paths should be added.
+     */
+    @Test
+    public void testEmptyDependencyExtractedDir_onlyBasePathsAdded() throws Exception {
+
+        createDependencyExtractedDir();
+
+        loader.init(projectRoot.toString());
+
+        List<String> paths = loader.getConnectorsZipFolderPaths();
+        assertEquals(2, paths.size(),
+                "No extra paths should be added for an empty dependency extracted dir");
+    }
+
+    /**
+     * When a dependency project has a connectors directory, that path should be added.
+     */
+    @Test
+    public void testDependencyProjectWithConnectors_pathAdded() throws Exception {
+
+        Path extractedDir = createDependencyExtractedDir();
+        Path depProject = extractedDir.resolve("dep-project-A");
+        Path connectorDir = depProject.resolve(CONNECTOR_RELATIVE_PATH);
+        Files.createDirectories(connectorDir);
+
+        loader.init(projectRoot.toString());
+        loader.loadConnector();
+
+        List<String> paths = loader.getConnectorsZipFolderPaths();
+        assertEquals(3, paths.size(),
+                "The dependency project's connector path should be added");
+        assertTrue(paths.contains(connectorDir.toString()),
+                "Expected connector path not found: " + connectorDir);
+    }
+
+    /**
+     * When a dependency project exists but does not have a connectors directory,
+     * no extra path should be added for it.
+     */
+    @Test
+    public void testDependencyProjectWithoutConnectors_pathNotAdded() throws Exception {
+
+        Path extractedDir = createDependencyExtractedDir();
+        // Dependency project with some structure but no connectors dir
+        Files.createDirectories(extractedDir.resolve("dep-project-B").resolve("src").resolve("main"));
+
+        loader.init(projectRoot.toString());
+
+        List<String> paths = loader.getConnectorsZipFolderPaths();
+        assertEquals(2, paths.size(),
+                "No extra path should be added when dependency project has no connectors dir");
+    }
+
+    /**
+     * When multiple dependency projects exist, only those that have a connectors directory
+     * should contribute a path.
+     */
+    @Test
+    public void testMultipleDependencyProjects_onlyThoseWithConnectorsAdded() throws Exception {
+
+        Path extractedDir = createDependencyExtractedDir();
+
+        // Project with connectors dir
+        Path depWithConnectors = extractedDir.resolve("dep-with-connectors");
+        Path connectorDir = depWithConnectors.resolve(CONNECTOR_RELATIVE_PATH);
+        Files.createDirectories(connectorDir);
+
+        // Project without connectors dir
+        Files.createDirectories(extractedDir.resolve("dep-without-connectors").resolve("src"));
+
+        loader.init(projectRoot.toString());
+        loader.loadConnector();
+
+        List<String> paths = loader.getConnectorsZipFolderPaths();
+        assertEquals(3, paths.size(),
+                "Only the dependency project with a connectors dir should add a path");
+        assertTrue(paths.contains(connectorDir.toString()),
+                "Expected connector path not found: " + connectorDir);
+    }
+
+    /**
+     * When there are multiple dependency projects all having connectors directories,
+     * all their paths should be added.
+     */
+    @Test
+    public void testMultipleDependencyProjects_allWithConnectors_allPathsAdded() throws Exception {
+
+        Path extractedDir = createDependencyExtractedDir();
+
+        Path connectorDirA = extractedDir.resolve("dep-A").resolve(CONNECTOR_RELATIVE_PATH);
+        Path connectorDirB = extractedDir.resolve("dep-B").resolve(CONNECTOR_RELATIVE_PATH);
+        Files.createDirectories(connectorDirA);
+        Files.createDirectories(connectorDirB);
+
+        loader.init(projectRoot.toString());
+        loader.loadConnector();
+
+        List<String> paths = loader.getConnectorsZipFolderPaths();
+        assertEquals(4, paths.size(),
+                "Both dependency connector paths should be added");
+        assertTrue(paths.contains(connectorDirA.toString()));
+        assertTrue(paths.contains(connectorDirB.toString()));
+    }
+
+    /**
+     * {@code loadConnector()} refreshes dependency paths on each call. After adding a new
+     * dependency project's connector directory, a subsequent {@code loadConnector()} call
+     * should pick it up.
+     */
+    @Test
+    public void testLoadConnector_refreshesDependencyPaths() throws Exception {
+
+        loader.init(projectRoot.toString());
+
+        // Initially no dependency dir — only 2 base paths
+        assertEquals(2, loader.getConnectorsZipFolderPaths().size());
+
+        // Now add a dependency project with connectors
+        Path extractedDir = createDependencyExtractedDir();
+        Path connectorDir = extractedDir.resolve("new-dep").resolve(CONNECTOR_RELATIVE_PATH);
+        Files.createDirectories(connectorDir);
+
+        loader.loadConnector();
+
+        List<String> paths = loader.getConnectorsZipFolderPaths();
+        assertEquals(3, paths.size(),
+                "loadConnector() should re-scan and pick up the newly added dependency connector path");
+        assertTrue(paths.contains(connectorDir.toString()));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates the dependency extracted directory for the current project under the temp home,
+     * mirroring the path that {@link NewProjectConnectorLoader} expects.
+     */
+    private Path createDependencyExtractedDir() throws IOException {
+
+        String projectName = projectRoot.toFile().getName();
+        String hash = Utils.getHash(projectRoot.toString());
+        String projectId = projectName + "_" + hash;
+
+        Path extractedDir = tempHome.resolve(Constant.WSO2_MI)
+                .resolve(Constant.INTEGRATION_PROJECT_DEPENDENCIES)
+                .resolve(projectId)
+                .resolve(Constant.EXTRACTED);
+        Files.createDirectories(extractedDir);
+        return extractedDir;
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        Files.walk(path)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+    }
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -19,7 +19,6 @@ import org.eclipse.lemminx.customservice.SynapseLanguageClientAPI;
 import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
 import org.eclipse.lemminx.customservice.synapse.connectors.NewProjectConnectorLoader;
 import org.eclipse.lemminx.customservice.synapse.inbound.conector.InboundConnectorHolder;
-import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 import org.eclipse.lemminx.customservice.synapse.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.logging.Logger;
 
 import static org.eclipse.lemminx.synapse.TestUtils.getResourceFilePath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,15 +42,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class NewDependentProjectConnectorLoaderTest {
 
+    private static final Logger LOGGER = Logger.getLogger(NewDependentProjectConnectorLoaderTest.class.getName());
+
     /**
      * Minimal subclass that exposes {@code connectorsZipFolderPath} for assertions
      * and skips the copy-to-project step which is irrelevant for dependency loading.
      */
     static class TestableLoader extends NewProjectConnectorLoader {
 
+        private final String userHome;
+
         TestableLoader(SynapseLanguageClientAPI client, ConnectorHolder holder,
-                       InboundConnectorHolder inboundHolder) {
+                       InboundConnectorHolder inboundHolder, String userHome) {
             super(client, holder, inboundHolder);
+            this.userHome = userHome;
+        }
+
+        @Override
+        protected String getUserHome() {
+            return userHome;
         }
 
         List<String> getConnectorsZipFolderPaths() {
@@ -67,7 +77,6 @@ public class NewDependentProjectConnectorLoaderTest {
             Constant.SRC + File.separator + Constant.MAIN + File.separator +
             Constant.WSO2MI + File.separator + Constant.RESOURCES + File.separator + Constant.CONNECTORS;
 
-    private String originalUserHome;
     private Path tempHome;
     private Path projectRoot;
     private TestableLoader loader;
@@ -75,10 +84,8 @@ public class NewDependentProjectConnectorLoaderTest {
     @BeforeEach
     public void setUp() throws IOException {
 
-        originalUserHome = System.getProperty(Constant.USER_HOME);
-
+        LOGGER.info("Setting up test environment for NewDependentProjectConnectorLoaderTest");
         tempHome = Files.createTempDirectory("mi-test-home-");
-        System.setProperty(Constant.USER_HOME, tempHome.toString());
 
         // Create a minimal valid project root (requires pom.xml and src/)
         projectRoot = Files.createTempDirectory("mi-test-project-");
@@ -90,13 +97,13 @@ public class NewDependentProjectConnectorLoaderTest {
         InboundConnectorHolder inboundConnectorHolder = new InboundConnectorHolder();
         SynapseLanguageClientAPI languageClient = new MockXMLLanguageClient();
 
-        loader = new TestableLoader(languageClient, connectorHolder, inboundConnectorHolder);
+        loader = new TestableLoader(languageClient, connectorHolder, inboundConnectorHolder, tempHome.toString());
     }
 
     @AfterEach
     public void tearDown() throws IOException {
 
-        System.setProperty(Constant.USER_HOME, originalUserHome);
+        LOGGER.info("Tearing down test environment for NewDependentProjectConnectorLoaderTest");
         deleteRecursively(tempHome);
         deleteRecursively(projectRoot);
     }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -912,7 +913,7 @@ public class IntegrationProjectDownloadManagerTest {
      * must be a new copy, not the original.
      */
     @Test
-    public void testRefetch_existingCarInDownloaded_replacedByFreshCopy() throws IOException, InterruptedException {
+    public void testRefetch_existingCarInDownloaded_replacedByFreshCopy() throws IOException {
 
         DependencyDetails dep = makeDep("com.example", "dep-a", "1.0.0", "car");
 
@@ -921,20 +922,18 @@ public class IntegrationProjectDownloadManagerTest {
 
         // Pre-place a .car in Downloaded (simulates a prior fetch)
         createZipWithDescriptor(downloadDir, carFileName(dep), false, Collections.emptyList());
-        long originalLastModified = downloadDir.resolve(carFileName(dep)).toFile().lastModified();
-
+        // Explicitly set an old timestamp to avoid relying on OS clock resolution
+        long pastTime = System.currentTimeMillis() - 10_000;
+        Files.setLastModifiedTime(downloadDir.resolve(carFileName(dep)), FileTime.fromMillis(pastTime));
         // Plant a fresh .car in the local repo
         plantInLocalRepo(dep, false, Collections.emptyList());
-
-        // Small sleep to ensure a different timestamp on the re-fetched file
-        Thread.sleep(10);
 
         IntegrationProjectDownloadManager.refetchDependencies(
                 projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(downloadDir.resolve(carFileName(dep)).toFile().exists(),
                 "dep .car should be present in Downloaded after refetch");
-        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().lastModified() > originalLastModified,
+        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().lastModified() > pastTime,
                 "Re-fetched .car must be a new copy — last-modified must be newer than the original");
     }
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
@@ -55,23 +55,19 @@ import static org.mockito.Mockito.mockStatic;
  */
 public class IntegrationProjectDownloadManagerTest {
 
-    private String originalUserHome;
     private Path tempHome;
     private Path projectRoot;
 
     @BeforeEach
     public void setUp() throws IOException {
 
-        originalUserHome = System.getProperty(Constant.USER_HOME);
         tempHome = Files.createTempDirectory("mi-test-home-");
-        System.setProperty(Constant.USER_HOME, tempHome.toString());
         projectRoot = Files.createTempDirectory("mi-test-project-");
     }
 
     @AfterEach
     public void tearDown() throws IOException {
 
-        System.setProperty(Constant.USER_HOME, originalUserHome);
         deleteRecursively(tempHome);
         deleteRecursively(projectRoot);
     }
@@ -88,7 +84,7 @@ public class IntegrationProjectDownloadManagerTest {
     public void testEmptyDependencies_allResultListsEmptyAndDirectoriesCreated() {
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), Collections.emptyList(), false);
+                projectRoot.toString(), Collections.emptyList(), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
         assertTrue(result.getNoDescriptorDependencies().isEmpty());
@@ -121,7 +117,7 @@ public class IntegrationProjectDownloadManagerTest {
             utilsMock.when(() -> Utils.deleteDirectory(any())).thenCallRealMethod();
 
             DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                    projectRoot.toString(), List.of(dep), false);
+                    projectRoot.toString(), List.of(dep), false, tempHome);
 
             assertEquals(1, result.getFailedDependencies().size());
             assertTrue(result.getFailedDependencies().get(0).contains("my-project"));
@@ -151,7 +147,7 @@ public class IntegrationProjectDownloadManagerTest {
         createZipWithoutDescriptor(repoDir, dep.getArtifact() + "-" + dep.getVersion() + ".car");
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertEquals(1, result.getNoDescriptorDependencies().size());
         assertTrue(result.getNoDescriptorDependencies().get(0).contains("no-descriptor"));
@@ -173,7 +169,7 @@ public class IntegrationProjectDownloadManagerTest {
         plantInLocalRepo(dep, true, Collections.emptyList());
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertEquals(1, result.getVersioningTypeMismatchDependencies().size());
         assertTrue(result.getVersioningTypeMismatchDependencies().get(0).contains("versioned-dep"));
@@ -200,7 +196,7 @@ public class IntegrationProjectDownloadManagerTest {
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
         assertTrue(result.getNoDescriptorDependencies().isEmpty());
@@ -226,7 +222,7 @@ public class IntegrationProjectDownloadManagerTest {
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(rootDep), false);
+                projectRoot.toString(), List.of(rootDep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
         assertTrue(result.getNoDescriptorDependencies().isEmpty());
@@ -259,7 +255,7 @@ public class IntegrationProjectDownloadManagerTest {
 
         // Nothing planted in local repo — if the code tries to fetch it would find nothing
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
         assertTrue(result.getNoDescriptorDependencies().isEmpty());
@@ -291,7 +287,7 @@ public class IntegrationProjectDownloadManagerTest {
 
         // Nothing planted in local repo — if the code tries to fetch it would find nothing
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
         assertTrue(result.getNoDescriptorDependencies().isEmpty());
@@ -327,7 +323,7 @@ public class IntegrationProjectDownloadManagerTest {
         createZipWithDescriptor(downloadDir, obsoleteBaseName + ".zip", false, Collections.emptyList());
 
         IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), Collections.emptyList(), false);
+                projectRoot.toString(), Collections.emptyList(), false, tempHome);
 
         assertFalse(obsoleteDir.toFile().exists(),
                 "Obsolete Extracted dir should have been deleted");
@@ -353,7 +349,7 @@ public class IntegrationProjectDownloadManagerTest {
         createZipWithDescriptor(downloadDir, obsoleteBaseName + ".car", false, Collections.emptyList());
 
         IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), Collections.emptyList(), false);
+                projectRoot.toString(), Collections.emptyList(), false, tempHome);
 
         assertFalse(downloadDir.resolve(obsoleteBaseName + ".car").toFile().exists(),
                 "Obsolete .car in Downloaded should have been deleted");
@@ -378,7 +374,7 @@ public class IntegrationProjectDownloadManagerTest {
         createZipWithDescriptor(downloadDir, carBaseName(dep) + ".zip", false, Collections.emptyList());
 
         IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(keepExtracted.toFile().exists(),
                 "Extracted dir for a current dependency must not be deleted");
@@ -417,7 +413,7 @@ public class IntegrationProjectDownloadManagerTest {
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
         IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(depA, depB, depC), false);
+                projectRoot.toString(), List.of(depA, depB, depC), false, tempHome);
 
         File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
         assertEquals(3, downloadedFiles != null ? downloadedFiles.length : 0,
@@ -446,7 +442,7 @@ public class IntegrationProjectDownloadManagerTest {
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
         IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(rootDep), false);
+                projectRoot.toString(), List.of(rootDep), false, tempHome);
 
         File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
         assertEquals(2, downloadedFiles != null ? downloadedFiles.length : 0,
@@ -481,7 +477,7 @@ public class IntegrationProjectDownloadManagerTest {
 
         // New run: depC removed from pom — only depA and depB in the list
         IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(depA, depB), false);
+                projectRoot.toString(), List.of(depA, depB), false, tempHome);
 
         // Downloaded: only depA and depB .zips should remain; depC .zip must be deleted
         File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
@@ -533,7 +529,7 @@ public class IntegrationProjectDownloadManagerTest {
         plantInLocalRepo(newDep, false, Collections.emptyList());
 
         IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(newDep), false);
+                projectRoot.toString(), List.of(newDep), false, tempHome);
 
         // Extracted: both old dirs must be gone
         assertFalse(extractedRoot.resolve(carBaseName(oldDep1)).toFile().exists(),
@@ -578,7 +574,7 @@ public class IntegrationProjectDownloadManagerTest {
         plantInLocalRepo(newDep, false, Collections.emptyList());
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(existingDep, newDep), false);
+                projectRoot.toString(), List.of(existingDep, newDep), false, tempHome);
 
         // Extracted: existingDep's dir must be preserved
         assertTrue(extractedRoot.resolve(carBaseName(existingDep)).toFile().exists(),
@@ -628,7 +624,7 @@ public class IntegrationProjectDownloadManagerTest {
 
         // New dep list: only rootDep — anotherDep was removed from pom
         IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(rootDep), false);
+                projectRoot.toString(), List.of(rootDep), false, tempHome);
 
         // rootDep and its transitiveDep must be preserved in both directories
         assertTrue(extractedRoot.resolve(carBaseName(rootDep)).toFile().exists(),
@@ -666,7 +662,7 @@ public class IntegrationProjectDownloadManagerTest {
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(dep, dep), false);
+                projectRoot.toString(), List.of(dep, dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
         assertTrue(result.getNoDescriptorDependencies().isEmpty());
@@ -695,7 +691,7 @@ public class IntegrationProjectDownloadManagerTest {
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
-                projectRoot.toString(), List.of(goodDep, badDep), false);
+                projectRoot.toString(), List.of(goodDep, badDep), false, tempHome);
 
         assertEquals(1, result.getFailedDependencies().size());
         assertTrue(result.getFailedDependencies().get(0).contains("bad-dep"));
@@ -834,7 +830,7 @@ public class IntegrationProjectDownloadManagerTest {
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.refetchDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
         assertTrue(result.getNoDescriptorDependencies().isEmpty());
@@ -869,7 +865,7 @@ public class IntegrationProjectDownloadManagerTest {
         plantInLocalRepo(dep, false, Collections.emptyList());
 
         IntegrationProjectDownloadManager.refetchDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         // Stale dep must be gone from both dirs
         assertFalse(downloadDir.resolve(carBaseName(staleDep) + ".zip").toFile().exists(),
@@ -901,7 +897,7 @@ public class IntegrationProjectDownloadManagerTest {
         plantInLocalRepo(dep, false, Collections.emptyList());
 
         IntegrationProjectDownloadManager.refetchDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertFalse(downloadDir.resolve(carFileName(staleDep)).toFile().exists(),
                 "Stale .car should have been cleared from Downloaded");
@@ -934,7 +930,7 @@ public class IntegrationProjectDownloadManagerTest {
         Thread.sleep(10);
 
         IntegrationProjectDownloadManager.refetchDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(downloadDir.resolve(carFileName(dep)).toFile().exists(),
                 "dep .car should be present in Downloaded after refetch");
@@ -965,7 +961,7 @@ public class IntegrationProjectDownloadManagerTest {
         plantInLocalRepo(dep, false, Collections.emptyList());
 
         IntegrationProjectDownloadManager.refetchDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         // Old .zip must be gone, replaced by a freshly fetched .car
         assertFalse(downloadDir.resolve(carBaseName(dep) + ".zip").toFile().exists(),
@@ -1000,7 +996,7 @@ public class IntegrationProjectDownloadManagerTest {
         plantInLocalRepo(depA, false, Collections.emptyList());
 
         IntegrationProjectDownloadManager.refetchDependencies(
-                projectRoot.toString(), List.of(depA), false);
+                projectRoot.toString(), List.of(depA), false, tempHome);
 
         // Extracted dir must be completely empty — no directories from the prior run remain
         File[] extractedDirs = extractedRoot.toFile().listFiles(File::isDirectory);
@@ -1019,7 +1015,7 @@ public class IntegrationProjectDownloadManagerTest {
         plantInLocalRepo(dep, false, Collections.emptyList());
 
         DependencyDownloadResult result = IntegrationProjectDownloadManager.refetchDependencies(
-                projectRoot.toString(), List.of(dep), false);
+                projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
         assertTrue(result.getNoDescriptorDependencies().isEmpty());

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
@@ -1,0 +1,829 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.synapse.parser;
+
+import org.eclipse.lemminx.customservice.synapse.parser.DependencyDetails;
+import org.eclipse.lemminx.customservice.synapse.parser.DependencyDownloadResult;
+import org.eclipse.lemminx.customservice.synapse.parser.IntegrationProjectDownloadManager;
+import org.eclipse.lemminx.customservice.synapse.utils.Constant;
+import org.eclipse.lemminx.customservice.synapse.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Tests for {@link IntegrationProjectDownloadManager}.
+ *
+ * <p>File lifecycle in the Downloaded directory:
+ * <ul>
+ *   <li><b>Pre-extraction</b>: dependency is copied from the local Maven repo as
+ *       {@code groupId-artifactId-version.car}</li>
+ *   <li><b>Post-extraction</b>: after the .car is extracted (by an external step) the file
+ *       is renamed to {@code groupId-artifactId-version.zip} in the Downloaded directory,
+ *       and a corresponding directory is created under Extracted.</li>
+ * </ul>
+ */
+public class IntegrationProjectDownloadManagerTest {
+
+    private String originalUserHome;
+    private Path tempHome;
+    private Path projectRoot;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+
+        originalUserHome = System.getProperty(Constant.USER_HOME);
+        tempHome = Files.createTempDirectory("mi-test-home-");
+        System.setProperty(Constant.USER_HOME, tempHome.toString());
+        projectRoot = Files.createTempDirectory("mi-test-project-");
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+
+        System.setProperty(Constant.USER_HOME, originalUserHome);
+        deleteRecursively(tempHome);
+        deleteRecursively(projectRoot);
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadDependencies — directory setup
+    // -------------------------------------------------------------------------
+
+    /**
+     * With an empty dependency list, all result lists should be empty
+     * and the working directories should be created.
+     */
+    @Test
+    public void testEmptyDependencies_allResultListsEmptyAndDirectoriesCreated() {
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), Collections.emptyList(), false);
+
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+
+        Path baseDir = resolveProjectBaseDir();
+        assertTrue(baseDir.resolve(Constant.DOWNLOADED).toFile().isDirectory(),
+                "Downloaded directory should be created");
+        assertTrue(baseDir.resolve(Constant.EXTRACTED).toFile().isDirectory(),
+                "Extracted directory should be created");
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadDependencies — dependency not available
+    // -------------------------------------------------------------------------
+
+    /**
+     * When a dependency cannot be found in the local repository (and no prior download
+     * exists), it should be reported as a failed dependency.
+     */
+    @Test
+    public void testDependencyNotInLocalRepo_addedToFailedList() {
+
+        DependencyDetails dep = makeDep("com.example", "my-project", "1.0.0", "car");
+
+        try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
+            utilsMock.when(() -> Utils.getDependencyFromLocalRepo(any(), any(), any(), any()))
+                    .thenReturn(null);
+            utilsMock.when(() -> Utils.getHash(any())).thenCallRealMethod();
+            utilsMock.when(() -> Utils.deleteDirectory(any())).thenCallRealMethod();
+
+            DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                    projectRoot.toString(), List.of(dep), false);
+
+            assertEquals(1, result.getFailedDependencies().size());
+            assertTrue(result.getFailedDependencies().get(0).contains("my-project"));
+            assertTrue(result.getNoDescriptorDependencies().isEmpty());
+            assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadDependencies — descriptor parsing errors
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the .car in the local repo has no {@code descriptor.xml}, the dependency should
+     * be reported in {@code noDescriptorDependencies}.
+     */
+    @Test
+    public void testCarWithoutDescriptor_addedToNoDescriptorList() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "no-descriptor", "1.0.0", "car");
+
+        // Plant a .car without descriptor.xml in the local repo — Downloaded starts empty
+        Path repoDir = tempHome.resolve(Constant.M2).resolve(Constant.REPOSITORY)
+                .resolve(dep.getGroupId().replace(".", File.separator))
+                .resolve(dep.getArtifact()).resolve(dep.getVersion());
+        Files.createDirectories(repoDir);
+        createZipWithoutDescriptor(repoDir, dep.getArtifact() + "-" + dep.getVersion() + ".car");
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertEquals(1, result.getNoDescriptorDependencies().size());
+        assertTrue(result.getNoDescriptorDependencies().get(0).contains("no-descriptor"));
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+    }
+
+    /**
+     * When the .car in the local repo has a {@code versionedDeployment} value that differs
+     * from the parent project's setting, the dependency should be reported in
+     * {@code versioningTypeMismatchDependencies}.
+     */
+    @Test
+    public void testCarWithVersioningMismatch_addedToVersioningMismatchList() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "versioned-dep", "2.0.0", "car");
+
+        // Plant a .car with versionedDeployment=true in the local repo; parent has false
+        plantInLocalRepo(dep, true, Collections.emptyList());
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertEquals(1, result.getVersioningTypeMismatchDependencies().size());
+        assertTrue(result.getVersioningTypeMismatchDependencies().get(0).contains("versioned-dep"));
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadDependencies — successful scenarios
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the .car file is valid (descriptor.xml present, versioning matches) and lists
+     * no transitive dependencies, it should not appear in any failure list.
+     */
+    @Test
+    public void testValidCarWithNoDeps_noFailures() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "valid-dep", "1.0.0", "car");
+
+        // Plant .car in local repo — Downloaded starts empty
+        plantInLocalRepo(dep, false, Collections.emptyList());
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().exists(),
+                "dep .car should be present in Downloaded after fetch");
+    }
+
+    /**
+     * When a valid .car lists transitive dependencies that are themselves resolvable,
+     * no failures should be reported.
+     */
+    @Test
+    public void testValidCarWithTransitiveDep_noFailures() throws IOException {
+
+        DependencyDetails transitiveDep = makeDep("com.example", "transitive-dep", "1.0.0", "car");
+        DependencyDetails rootDep = makeDep("com.example", "root-dep", "1.0.0", "car");
+
+        // Plant both .car files in local repo — Downloaded starts empty
+        plantInLocalRepo(rootDep, false, List.of(transitiveDep));
+        plantInLocalRepo(transitiveDep, false, Collections.emptyList());
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(rootDep), false);
+
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+        assertTrue(downloadDir.resolve(carFileName(rootDep)).toFile().exists(),
+                "rootDep .car should be present in Downloaded after fetch");
+        assertTrue(downloadDir.resolve(carFileName(transitiveDep)).toFile().exists(),
+                "transitiveDep .car should be present in Downloaded after fetch");
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadDependencies — skip when file already in Downloaded
+    // -------------------------------------------------------------------------
+
+    /**
+     * When a .car already exists in the Downloaded directory for a dependency, the local
+     * repo must not be consulted — the existing .car is used directly for descriptor parsing.
+     */
+    @Test
+    public void testCarAlreadyInDownloaded_localRepoNotConsulted() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "cached-dep", "1.0.0", "car");
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        Files.createDirectories(downloadDir);
+
+        // Place a valid .car directly in Downloaded (simulates a prior fetch)
+        Path existingCar = downloadDir.resolve(carFileName(dep));
+        createZipWithDescriptor(downloadDir, carFileName(dep), false, Collections.emptyList());
+        long lastModifiedBefore = existingCar.toFile().lastModified();
+
+        // Nothing planted in local repo — if the code tries to fetch it would find nothing
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+        // File count must remain 1 — no duplicate copy
+        File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
+        assertEquals(1, downloadedFiles != null ? downloadedFiles.length : 0,
+                "Downloaded dir should still contain exactly the one pre-existing .car");
+        // The pre-existing file must not have been touched
+        assertEquals(lastModifiedBefore, existingCar.toFile().lastModified(),
+                "Pre-existing .car must not be modified — it should be reused as-is");
+    }
+
+    /**
+     * When a post-extraction .zip already exists in the Downloaded directory (no Extracted dir),
+     * the local repo must not be consulted — the existing .zip is used directly for descriptor parsing.
+     */
+    @Test
+    public void testZipAlreadyInDownloaded_localRepoNotConsulted() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "cached-dep", "1.0.0", "car");
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        Files.createDirectories(downloadDir);
+
+        // Place a valid .zip directly in Downloaded (simulates post-extraction state without Extracted dir)
+        Path existingZip = downloadDir.resolve(carBaseName(dep) + ".zip");
+        createZipWithDescriptor(downloadDir, carBaseName(dep) + ".zip", false, Collections.emptyList());
+        long lastModifiedBefore = existingZip.toFile().lastModified();
+
+        // Nothing planted in local repo — if the code tries to fetch it would find nothing
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+        File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
+        assertEquals(1, downloadedFiles != null ? downloadedFiles.length : 0,
+                "Downloaded dir should still contain exactly the one pre-existing .zip");
+        // The pre-existing file must not have been touched
+        assertEquals(lastModifiedBefore, existingZip.toFile().lastModified(),
+                "Pre-existing .zip must not be modified — it should be reused as-is");
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadDependencies — obsolete file/directory cleanup
+    // -------------------------------------------------------------------------
+
+    /**
+     * An obsolete Extracted dir (not in the current dep list) must be deleted.
+     * The corresponding post-extraction .zip in Downloaded must also be deleted.
+     */
+    @Test
+    public void testObsoleteExtractedDirAndZip_areBothDeleted() throws IOException {
+
+        Path baseDir = resolveProjectBaseDir();
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+        Files.createDirectories(extractedRoot);
+        Files.createDirectories(downloadDir);
+
+        String obsoleteBaseName = "old-group-old-artifact-0.0.1";
+        Path obsoleteDir = extractedRoot.resolve(obsoleteBaseName);
+        Files.createDirectory(obsoleteDir);
+        createZipWithDescriptor(downloadDir, obsoleteBaseName + ".zip", false, Collections.emptyList());
+
+        IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), Collections.emptyList(), false);
+
+        assertFalse(obsoleteDir.toFile().exists(),
+                "Obsolete Extracted dir should have been deleted");
+        assertFalse(downloadDir.resolve(obsoleteBaseName + ".zip").toFile().exists(),
+                "Obsolete .zip in Downloaded should have been deleted");
+    }
+
+    /**
+     * An obsolete pre-extraction .car in Downloaded (no corresponding Extracted dir, not
+     * in the current dep list) must be deleted.
+     */
+    @Test
+    public void testObsoleteCarInDownloaded_isDeleted() throws IOException {
+
+        Path baseDir = resolveProjectBaseDir();
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+        Files.createDirectories(downloadDir);
+        Files.createDirectories(extractedRoot);
+
+        // An obsolete .car that was never extracted — no matching Extracted dir
+        String obsoleteBaseName = "old-group-old-artifact-0.0.1";
+        createZipWithDescriptor(downloadDir, obsoleteBaseName + ".car", false, Collections.emptyList());
+
+        IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), Collections.emptyList(), false);
+
+        assertFalse(downloadDir.resolve(obsoleteBaseName + ".car").toFile().exists(),
+                "Obsolete .car in Downloaded should have been deleted");
+    }
+
+    /**
+     * Files in Downloaded and dirs in Extracted that ARE still in the current dep list
+     * must not be deleted.
+     */
+    @Test
+    public void testCurrentDepFiles_areNotDeleted() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "keep-dep", "1.0.0", "car");
+        Path baseDir = resolveProjectBaseDir();
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+
+        // Post-extraction state: Extracted dir + .zip in Downloaded
+        Path keepExtracted = extractedRoot.resolve(carBaseName(dep));
+        Files.createDirectories(keepExtracted);
+        Files.createDirectories(downloadDir);
+        createZipWithDescriptor(downloadDir, carBaseName(dep) + ".zip", false, Collections.emptyList());
+
+        IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertTrue(keepExtracted.toFile().exists(),
+                "Extracted dir for a current dependency must not be deleted");
+        assertTrue(downloadDir.resolve(carBaseName(dep) + ".zip").toFile().exists(),
+                "Downloaded .zip for a current dependency must not be deleted");
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadDependencies — Downloaded directory file count
+    // -------------------------------------------------------------------------
+
+    /**
+     * When 3 dependencies are resolved for the first time, exactly 3 .car files
+     * should be present in the Downloaded directory afterwards.
+     * <p>
+     * Files are planted in the fake local Maven repo under {@code tempHome/.m2/repository}
+     * so the real {@code getDependencyFromLocalRepo} finds them without any mocking.
+     * The Downloaded directory starts empty — .car files appear there only because
+     * {@code downloadDependencies} copies them via {@code copyFile}.
+     * </p>
+     */
+    @Test
+    public void testThreeDeps_exactlyThreeCarFilesInDownloadedDir() throws IOException {
+
+        DependencyDetails depA = makeDep("com.example", "dep-a", "1.0.0", "car");
+        DependencyDetails depB = makeDep("com.example", "dep-b", "1.0.0", "car");
+        DependencyDetails depC = makeDep("com.example", "dep-c", "1.0.0", "car");
+
+        // Plant .car files in the fake local Maven repo — NOT in downloadDir
+        plantInLocalRepo(depA, false, Collections.emptyList());
+        plantInLocalRepo(depB, false, Collections.emptyList());
+        plantInLocalRepo(depC, false, Collections.emptyList());
+
+        // Downloaded directory starts empty
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
+
+        IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(depA, depB, depC), false);
+
+        File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
+        assertEquals(3, downloadedFiles != null ? downloadedFiles.length : 0,
+                "Downloaded directory should contain exactly 3 .car files copied from the local repo");
+    }
+
+    /**
+     * When a dependency references a transitive dependency, both the root .car and the
+     * transitive .car should be present in the Downloaded directory (2 files total).
+     * <p>
+     * Both files are planted in the fake local Maven repo; Downloaded starts empty.
+     * </p>
+     */
+    @Test
+    public void testRootDepWithTransitiveDep_twoCarFilesInDownloadedDir() throws IOException {
+
+        DependencyDetails transitiveDep = makeDep("com.example", "transitive", "1.0.0", "car");
+        DependencyDetails rootDep = makeDep("com.example", "root", "1.0.0", "car");
+
+        // rootDep's descriptor lists transitiveDep as a dependency
+        plantInLocalRepo(rootDep, false, List.of(transitiveDep));
+        plantInLocalRepo(transitiveDep, false, Collections.emptyList());
+
+        // Downloaded directory starts empty
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
+
+        IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(rootDep), false);
+
+        File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
+        assertEquals(2, downloadedFiles != null ? downloadedFiles.length : 0,
+                "Downloaded directory should contain the root .car and the transitive .car");
+    }
+
+    /**
+     * When the dependency list shrinks from 3 to 2, the removed dep's post-extraction
+     * .zip in Downloaded AND its directory in Extracted must both be deleted.
+     * The two remaining deps' .zip files and Extracted dirs must be preserved.
+     */
+    @Test
+    public void testShrinkingDepList_removedDepCleanedFromBothDirectories() throws IOException {
+
+        DependencyDetails depA = makeDep("com.example", "dep-a", "1.0.0", "car");
+        DependencyDetails depB = makeDep("com.example", "dep-b", "1.0.0", "car");
+        DependencyDetails depC = makeDep("com.example", "dep-c", "1.0.0", "car");
+
+        Path baseDir = resolveProjectBaseDir();
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+
+        // Simulate post-extraction state from a prior run:
+        // Extracted dirs exist for all 3 deps; Downloaded has the renamed .zip files
+        Files.createDirectories(extractedRoot.resolve(carBaseName(depA)));
+        Files.createDirectories(extractedRoot.resolve(carBaseName(depB)));
+        Files.createDirectories(extractedRoot.resolve(carBaseName(depC)));
+        Files.createDirectories(downloadDir);
+        createZipWithDescriptor(downloadDir, carBaseName(depA) + ".zip", false, Collections.emptyList());
+        createZipWithDescriptor(downloadDir, carBaseName(depB) + ".zip", false, Collections.emptyList());
+        createZipWithDescriptor(downloadDir, carBaseName(depC) + ".zip", false, Collections.emptyList());
+
+        // New run: depC removed from pom — only depA and depB in the list
+        IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(depA, depB), false);
+
+        // Downloaded: only depA and depB .zips should remain; depC .zip must be deleted
+        File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
+        assertEquals(2, downloadedFiles != null ? downloadedFiles.length : 0,
+                "Downloaded directory should contain only the 2 remaining deps' .zip files");
+        assertTrue(downloadDir.resolve(carBaseName(depA) + ".zip").toFile().exists(),
+                "depA .zip should still be in Downloaded");
+        assertTrue(downloadDir.resolve(carBaseName(depB) + ".zip").toFile().exists(),
+                "depB .zip should still be in Downloaded");
+        assertFalse(downloadDir.resolve(carBaseName(depC) + ".zip").toFile().exists(),
+                "depC .zip should have been deleted from Downloaded");
+
+        // Extracted: only depA and depB dirs should remain; depC dir must be deleted
+        File[] extractedFiles = extractedRoot.toFile().listFiles(File::isDirectory);
+		assertEquals(2, extractedFiles != null ? extractedFiles.length : 0,
+                "Extracted directory should contain only the 2 remaining deps' project directories");
+		assertTrue(extractedRoot.resolve(carBaseName(depA)).toFile().exists(),
+                "depA Extracted dir should still exist");
+        assertTrue(extractedRoot.resolve(carBaseName(depB)).toFile().exists(),
+                "depB Extracted dir should still exist");
+        assertFalse(extractedRoot.resolve(carBaseName(depC)).toFile().exists(),
+                "depC Extracted dir should have been deleted");
+    }
+
+    /**
+     * When the new dep list is completely different from the previous one, all old
+     * Extracted dirs AND their corresponding .zip files in Downloaded must be deleted.
+     * newDep is fetched fresh from the local repo (pre-extraction .car).
+     */
+    @Test
+    public void testCompletelyNewDepList_allOldFilesCleanedFromBothDirectories() throws IOException {
+
+        DependencyDetails oldDep1 = makeDep("com.example", "old-dep-1", "1.0.0", "car");
+        DependencyDetails oldDep2 = makeDep("com.example", "old-dep-2", "1.0.0", "car");
+        DependencyDetails newDep  = makeDep("com.example", "new-dep",   "2.0.0", "car");
+
+        Path baseDir = resolveProjectBaseDir();
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+
+        // Simulate post-extraction state for old deps: Extracted dirs + .zips in Downloaded
+        Files.createDirectories(extractedRoot.resolve(carBaseName(oldDep1)));
+        Files.createDirectories(extractedRoot.resolve(carBaseName(oldDep2)));
+        Files.createDirectories(downloadDir);
+        createZipWithDescriptor(downloadDir, carBaseName(oldDep1) + ".zip", false, Collections.emptyList());
+        createZipWithDescriptor(downloadDir, carBaseName(oldDep2) + ".zip", false, Collections.emptyList());
+
+        // newDep is fetched fresh from local repo (pre-extraction .car)
+        plantInLocalRepo(newDep, false, Collections.emptyList());
+
+        IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(newDep), false);
+
+        // Extracted: both old dirs must be gone
+        assertFalse(extractedRoot.resolve(carBaseName(oldDep1)).toFile().exists(),
+                "Old extracted dir 1 should have been deleted");
+        assertFalse(extractedRoot.resolve(carBaseName(oldDep2)).toFile().exists(),
+                "Old extracted dir 2 should have been deleted");
+        File[] remainingDirs = extractedRoot.toFile().listFiles(File::isDirectory);
+        assertEquals(0, remainingDirs != null ? remainingDirs.length : 0,
+                "No extracted directories should remain after switching to a completely new dep list");
+
+        // Downloaded: old .zips must be gone; only newDep's .car should be present
+        assertFalse(downloadDir.resolve(carBaseName(oldDep1) + ".zip").toFile().exists(),
+                "Old dep 1 .zip should have been deleted from Downloaded");
+        assertFalse(downloadDir.resolve(carBaseName(oldDep2) + ".zip").toFile().exists(),
+                "Old dep 2 .zip should have been deleted from Downloaded");
+        assertTrue(downloadDir.resolve(carFileName(newDep)).toFile().exists(),
+                "newDep .car should be present in Downloaded");
+    }
+
+    /**
+     * When the dep list grows (new dep added alongside an existing one):
+     * - existingDep's Extracted dir and .zip in Downloaded must be preserved
+     * - newDep's .car must be copied into Downloaded
+     * - no failures should be reported
+     */
+    @Test
+    public void testGrowingDepList_existingFilesPreservedAndNewDepFetched() throws IOException {
+
+        DependencyDetails existingDep = makeDep("com.example", "existing-dep", "1.0.0", "car");
+        DependencyDetails newDep      = makeDep("com.example", "new-dep",      "1.0.0", "car");
+
+        Path baseDir = resolveProjectBaseDir();
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+
+        // existingDep: post-extraction state — Extracted dir + .zip in Downloaded
+        Files.createDirectories(extractedRoot.resolve(carBaseName(existingDep)));
+        Files.createDirectories(downloadDir);
+        createZipWithDescriptor(downloadDir, carBaseName(existingDep) + ".zip", false, Collections.emptyList());
+
+        // newDep: fetched fresh from local repo (pre-extraction .car)
+        plantInLocalRepo(newDep, false, Collections.emptyList());
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(existingDep, newDep), false);
+
+        // Extracted: existingDep's dir must be preserved
+        assertTrue(extractedRoot.resolve(carBaseName(existingDep)).toFile().exists(),
+                "Existing Extracted dir should be preserved");
+
+        // Downloaded: existingDep's .zip must be preserved; newDep's .car must be present
+        assertTrue(downloadDir.resolve(carBaseName(existingDep) + ".zip").toFile().exists(),
+                "Existing dep .zip should still be in Downloaded");
+        assertTrue(downloadDir.resolve(carFileName(newDep)).toFile().exists(),
+                "New dep .car should be present in Downloaded");
+
+        assertTrue(result.getFailedDependencies().isEmpty(), "No failures expected");
+    }
+
+    /**
+     * Scenario: 3 items exist in post-extraction state — rootDep, its transitiveDep,
+     * and an unrelated anotherDep. The new dep list contains only rootDep (anotherDep removed).
+     * <p>
+     * Expected outcome:
+     * <ul>
+     *   <li>rootDep and transitiveDep must be kept in both Downloaded and Extracted
+     *       (transitiveDep is still reachable via rootDep's descriptor)</li>
+     *   <li>anotherDep's .zip and Extracted dir must both be deleted</li>
+     * </ul>
+     */
+    @Test
+    public void testShrinkingDepList_transitiveOfRemainingDepIsPreserved() throws IOException {
+
+        DependencyDetails rootDep      = makeDep("com.example", "root-dep",      "1.0.0", "car");
+        DependencyDetails transitiveDep = makeDep("com.example", "transitive-dep", "1.0.0", "car");
+        DependencyDetails anotherDep   = makeDep("com.example", "another-dep",   "1.0.0", "car");
+
+        Path baseDir = resolveProjectBaseDir();
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+
+        // Simulate post-extraction state for all 3 deps:
+        // Extracted dirs exist; Downloaded has .zip files (renamed from .car after extraction)
+        // rootDep's .zip descriptor lists transitiveDep as a dependency
+        Files.createDirectories(extractedRoot.resolve(carBaseName(rootDep)));
+        Files.createDirectories(extractedRoot.resolve(carBaseName(transitiveDep)));
+        Files.createDirectories(extractedRoot.resolve(carBaseName(anotherDep)));
+        Files.createDirectories(downloadDir);
+        createZipWithDescriptor(downloadDir, carBaseName(rootDep) + ".zip", false, List.of(transitiveDep));
+        createZipWithDescriptor(downloadDir, carBaseName(transitiveDep) + ".zip", false, Collections.emptyList());
+        createZipWithDescriptor(downloadDir, carBaseName(anotherDep) + ".zip", false, Collections.emptyList());
+
+        // New dep list: only rootDep — anotherDep was removed from pom
+        IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(rootDep), false);
+
+        // rootDep and its transitiveDep must be preserved in both directories
+        assertTrue(extractedRoot.resolve(carBaseName(rootDep)).toFile().exists(),
+                "rootDep Extracted dir should be preserved");
+        assertTrue(extractedRoot.resolve(carBaseName(transitiveDep)).toFile().exists(),
+                "transitiveDep Extracted dir should be preserved — still reachable via rootDep");
+        assertTrue(downloadDir.resolve(carBaseName(rootDep) + ".zip").toFile().exists(),
+                "rootDep .zip should be preserved in Downloaded");
+        assertTrue(downloadDir.resolve(carBaseName(transitiveDep) + ".zip").toFile().exists(),
+                "transitiveDep .zip should be preserved in Downloaded — still reachable via rootDep");
+
+        // anotherDep must be removed from both directories
+        assertFalse(extractedRoot.resolve(carBaseName(anotherDep)).toFile().exists(),
+                "anotherDep Extracted dir should have been deleted");
+        assertFalse(downloadDir.resolve(carBaseName(anotherDep) + ".zip").toFile().exists(),
+                "anotherDep .zip should have been deleted from Downloaded");
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadDependencies — duplicate dependency handling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Providing the same dependency twice in the input list should not cause it to be
+     * processed twice — the second occurrence is silently skipped.
+     */
+    @Test
+    public void testDuplicateDependencyInList_processedOnlyOnce() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "dup-dep", "1.0.0", "car");
+
+        // Plant .car in local repo — Downloaded starts empty
+        plantInLocalRepo(dep, false, Collections.emptyList());
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(dep, dep), false);
+
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+
+        // Despite being listed twice, only one .car should be in Downloaded
+        File[] downloadedFiles = downloadDir.toFile().listFiles(File::isFile);
+        assertEquals(1, downloadedFiles != null ? downloadedFiles.length : 0,
+                "Duplicate dep should only be copied once into Downloaded");
+    }
+
+    /**
+     * When multiple dependencies are present and only one fails, only that one
+     * should appear in the failure list.
+     */
+    @Test
+    public void testMultipleDependencies_onlyFailedOneReported() throws IOException {
+
+        DependencyDetails goodDep = makeDep("com.example", "good-dep", "1.0.0", "car");
+        DependencyDetails badDep  = makeDep("com.example", "bad-dep",  "1.0.0", "car");
+
+        // goodDep is planted in the local repo — Downloaded starts empty
+        // badDep is not planted anywhere, so getDependencyFromLocalRepo returns null naturally
+        plantInLocalRepo(goodDep, false, Collections.emptyList());
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+                projectRoot.toString(), List.of(goodDep, badDep), false);
+
+        assertEquals(1, result.getFailedDependencies().size());
+        assertTrue(result.getFailedDependencies().get(0).contains("bad-dep"));
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+
+        // goodDep should have been copied as .car; badDep should not appear in Downloaded
+        assertTrue(downloadDir.resolve(carFileName(goodDep)).toFile().exists(),
+                "goodDep .car should be present in Downloaded");
+        assertFalse(downloadDir.resolve(carFileName(badDep)).toFile().exists(),
+                "badDep .car should not be present in Downloaded");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private DependencyDetails makeDep(String groupId, String artifactId, String version, String type) {
+
+        DependencyDetails dep = new DependencyDetails();
+        dep.setGroupId(groupId);
+        dep.setArtifact(artifactId);
+        dep.setVersion(version);
+        dep.setType(type);
+        return dep;
+    }
+
+    /** Returns {@code groupId-artifactId-version} — the base name used in both Downloaded and Extracted. */
+    private String carBaseName(DependencyDetails dep) {
+
+        return dep.getGroupId() + "-" + dep.getArtifact() + "-" + dep.getVersion();
+    }
+
+    /** Returns the pre-extraction filename: {@code groupId-artifactId-version.car}. */
+    private String carFileName(DependencyDetails dep) {
+
+        return carBaseName(dep) + "." + dep.getType();
+    }
+
+    /**
+     * Returns the base directory for this project under the temp home,
+     * mirroring the path that {@link IntegrationProjectDownloadManager} computes.
+     */
+    private Path resolveProjectBaseDir() {
+
+        String projectName = projectRoot.toFile().getName();
+        String hash = Utils.getHash(projectRoot.toString());
+        String projectId = projectName + "_" + hash;
+        return tempHome.resolve(Constant.WSO2_MI)
+                .resolve(Constant.INTEGRATION_PROJECT_DEPENDENCIES)
+                .resolve(projectId);
+    }
+
+    /**
+     * Plants a .car file with a {@code descriptor.xml} into the fake local Maven repository at
+     * {@code tempHome/.m2/repository/<groupId path>/<artifactId>/<version>/<artifactId>-<version>.car},
+     * mirroring the layout that {@link Utils#getDependencyFromLocalRepo} expects.
+     */
+    private void plantInLocalRepo(DependencyDetails dep, boolean versionedDeployment,
+                                  List<DependencyDetails> transitiveDeps) throws IOException {
+
+        Path repoDir = tempHome
+                .resolve(Constant.M2)
+                .resolve(Constant.REPOSITORY)
+                .resolve(dep.getGroupId().replace(".", File.separator))
+                .resolve(dep.getArtifact())
+                .resolve(dep.getVersion());
+        Files.createDirectories(repoDir);
+
+        // getDependencyFromLocalRepo looks for <artifactId>-<version>.<type>
+        String repoFileName = dep.getArtifact() + "-" + dep.getVersion() + "." + dep.getType();
+        createZipWithDescriptor(repoDir, repoFileName, versionedDeployment, transitiveDeps);
+    }
+
+    /**
+     * Creates a ZIP-format file in {@code dir} with the given {@code fileName} that contains
+     * no {@code descriptor.xml} (simulates a corrupt/incomplete .car).
+     */
+    private void createZipWithoutDescriptor(Path dir, String fileName) throws IOException {
+
+        Path zipPath = dir.resolve(fileName);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+            zos.putNextEntry(new ZipEntry("placeholder.txt"));
+            zos.write("no descriptor here".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+    }
+
+    /**
+     * Creates a ZIP-format file in {@code dir} with a {@code descriptor.xml} that declares the
+     * given {@code versionedDeployment} flag and lists {@code transitiveDeps} as dependencies.
+     * Used for both .car files (pre-extraction) and .zip files (post-extraction).
+     */
+    private void createZipWithDescriptor(Path dir, String fileName, boolean versionedDeployment,
+                                         List<DependencyDetails> transitiveDeps) throws IOException {
+
+        Path zipPath = dir.resolve(fileName);
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.append("<project>\n");
+        xml.append("  <versionedDeployment>").append(versionedDeployment).append("</versionedDeployment>\n");
+        xml.append("  <dependencies>\n");
+        for (DependencyDetails dep : transitiveDeps) {
+            xml.append("    <dependency")
+               .append(" groupId=\"").append(dep.getGroupId()).append("\"")
+               .append(" artifactId=\"").append(dep.getArtifact()).append("\"")
+               .append(" version=\"").append(dep.getVersion()).append("\"")
+               .append(" type=\"").append(dep.getType()).append("\"")
+               .append("/>\n");
+        }
+        xml.append("  </dependencies>\n");
+        xml.append("</project>\n");
+
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+            zos.putNextEntry(new ZipEntry("descriptor.xml"));
+            zos.write(xml.toString().getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        Files.walk(path)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+    }
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
@@ -816,6 +816,216 @@ public class IntegrationProjectDownloadManagerTest {
         }
     }
 
+    // =========================================================================
+    // refetchDependencies
+    // =========================================================================
+
+    /**
+     * When no prior state exists, refetchDependencies should behave identically to
+     * downloadDependencies — the dep is fetched from the local repo and placed in Downloaded.
+     */
+    @Test
+    public void testRefetch_noPriorState_fetchesFromLocalRepo() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "dep-a", "1.0.0", "car");
+        plantInLocalRepo(dep, false, Collections.emptyList());
+
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.refetchDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().exists(),
+                "dep .car should be present in Downloaded after refetch");
+    }
+
+    /**
+     * Downloaded and Extracted directories are fully cleared before re-fetching.
+     * All pre-existing files in both dirs must be gone before the new fetch runs.
+     */
+    @Test
+    public void testRefetch_clearsDownloadedAndExtractedBeforeFetching() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "dep-a", "1.0.0", "car");
+
+        Path baseDir = resolveProjectBaseDir();
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+
+        // Simulate prior state: stale files from a previous run
+        Files.createDirectories(downloadDir);
+        Files.createDirectories(extractedRoot);
+        createZipWithDescriptor(downloadDir, carBaseName(dep) + ".zip", false, Collections.emptyList());
+        Files.createDirectories(extractedRoot.resolve(carBaseName(dep)));
+        // An extra stale dep that is no longer in the dep list
+        DependencyDetails staleDep = makeDep("com.example", "stale-dep", "1.0.0", "car");
+        createZipWithDescriptor(downloadDir, carBaseName(staleDep) + ".zip", false, Collections.emptyList());
+        Files.createDirectories(extractedRoot.resolve(carBaseName(staleDep)));
+
+        plantInLocalRepo(dep, false, Collections.emptyList());
+
+        IntegrationProjectDownloadManager.refetchDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        // Stale dep must be gone from both dirs
+        assertFalse(downloadDir.resolve(carBaseName(staleDep) + ".zip").toFile().exists(),
+                "Stale .zip should have been cleared from Downloaded");
+        assertFalse(extractedRoot.resolve(carBaseName(staleDep)).toFile().exists(),
+                "Stale Extracted dir should have been cleared");
+
+        // dep was re-fetched as a fresh .car (old .zip was cleared, new .car copied in)
+        assertFalse(downloadDir.resolve(carBaseName(dep) + ".zip").toFile().exists(),
+                "Old .zip for dep should have been cleared");
+        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().exists(),
+                "Fresh .car for dep should be present in Downloaded after refetch");
+    }
+
+    /**
+     * A stale .car in Downloaded that was never extracted is also removed during the clear.
+     */
+    @Test
+    public void testRefetch_clearsStaleCarFromDownloaded() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "dep-a", "1.0.0", "car");
+        DependencyDetails staleDep = makeDep("com.example", "stale-dep", "1.0.0", "car");
+
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        Files.createDirectories(downloadDir);
+        // Stale .car that was never extracted
+        createZipWithDescriptor(downloadDir, carFileName(staleDep), false, Collections.emptyList());
+
+        plantInLocalRepo(dep, false, Collections.emptyList());
+
+        IntegrationProjectDownloadManager.refetchDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertFalse(downloadDir.resolve(carFileName(staleDep)).toFile().exists(),
+                "Stale .car should have been cleared from Downloaded");
+        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().exists(),
+                "Fresh .car for dep should be present in Downloaded after refetch");
+    }
+
+    /**
+     * Even if a .car for the dep is already present in Downloaded, refetchDependencies
+     * must clear it and re-fetch a fresh copy from the local repo.
+     * Verified by capturing the last-modified timestamp before and after — the file
+     * must be a new copy, not the original.
+     */
+    @Test
+    public void testRefetch_existingCarInDownloaded_replacedByFreshCopy() throws IOException, InterruptedException {
+
+        DependencyDetails dep = makeDep("com.example", "dep-a", "1.0.0", "car");
+
+        Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
+        Files.createDirectories(downloadDir);
+
+        // Pre-place a .car in Downloaded (simulates a prior fetch)
+        createZipWithDescriptor(downloadDir, carFileName(dep), false, Collections.emptyList());
+        long originalLastModified = downloadDir.resolve(carFileName(dep)).toFile().lastModified();
+
+        // Plant a fresh .car in the local repo
+        plantInLocalRepo(dep, false, Collections.emptyList());
+
+        // Small sleep to ensure a different timestamp on the re-fetched file
+        Thread.sleep(10);
+
+        IntegrationProjectDownloadManager.refetchDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().exists(),
+                "dep .car should be present in Downloaded after refetch");
+        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().lastModified() > originalLastModified,
+                "Re-fetched .car must be a new copy — last-modified must be newer than the original");
+    }
+
+    /**
+     * Even if a post-extraction .zip for the dep is already present in Downloaded,
+     * refetchDependencies must clear it and re-fetch a fresh .car from the local repo.
+     */
+    @Test
+    public void testRefetch_existingZipInDownloaded_replacedByFreshCar() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "dep-a", "1.0.0", "car");
+
+        Path baseDir = resolveProjectBaseDir();
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+
+        // Simulate post-extraction state: .zip in Downloaded + Extracted dir
+        Files.createDirectories(downloadDir);
+        Files.createDirectories(extractedRoot);
+        createZipWithDescriptor(downloadDir, carBaseName(dep) + ".zip", false, Collections.emptyList());
+        Files.createDirectories(extractedRoot.resolve(carBaseName(dep)));
+
+        // Plant a fresh .car in the local repo
+        plantInLocalRepo(dep, false, Collections.emptyList());
+
+        IntegrationProjectDownloadManager.refetchDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        // Old .zip must be gone, replaced by a freshly fetched .car
+        assertFalse(downloadDir.resolve(carBaseName(dep) + ".zip").toFile().exists(),
+                "Post-extraction .zip should have been cleared");
+        assertTrue(downloadDir.resolve(carFileName(dep)).toFile().exists(),
+                "Fresh .car must be present in Downloaded after refetch");
+    }
+
+    /**
+     * After a refetch, the Extracted directory must be empty — all previously extracted
+     * directories are cleared as part of the hard-refresh, regardless of whether they
+     * correspond to deps still in the current list.
+     */
+    @Test
+    public void testRefetch_extractedDirIsEmptiedAfterRefetch() throws IOException {
+
+        DependencyDetails depA = makeDep("com.example", "dep-a", "1.0.0", "car");
+        DependencyDetails depB = makeDep("com.example", "dep-b", "1.0.0", "car");
+
+        Path baseDir = resolveProjectBaseDir();
+        Path extractedRoot = baseDir.resolve(Constant.EXTRACTED);
+        Path downloadDir = baseDir.resolve(Constant.DOWNLOADED);
+
+        // Simulate post-extraction state for both deps
+        Files.createDirectories(extractedRoot.resolve(carBaseName(depA)));
+        Files.createDirectories(extractedRoot.resolve(carBaseName(depB)));
+        Files.createDirectories(downloadDir);
+        createZipWithDescriptor(downloadDir, carBaseName(depA) + ".zip", false, Collections.emptyList());
+        createZipWithDescriptor(downloadDir, carBaseName(depB) + ".zip", false, Collections.emptyList());
+
+        // Only depA is still in the dep list; depA is re-fetched as a fresh .car
+        plantInLocalRepo(depA, false, Collections.emptyList());
+
+        IntegrationProjectDownloadManager.refetchDependencies(
+                projectRoot.toString(), List.of(depA), false);
+
+        // Extracted dir must be completely empty — no directories from the prior run remain
+        File[] extractedDirs = extractedRoot.toFile().listFiles(File::isDirectory);
+        assertEquals(0, extractedDirs != null ? extractedDirs.length : 0,
+                "Extracted directory must be empty after refetch — prior extracted dirs are cleared");
+    }
+
+    /**
+     * After a refetch the result reflects only the current dep list — failures from
+     * stale deps that are no longer in the list are not reported.
+     */
+    @Test
+    public void testRefetch_resultReflectsOnlyCurrentDeps() throws IOException {
+
+        DependencyDetails dep = makeDep("com.example", "dep-a", "1.0.0", "car");
+        plantInLocalRepo(dep, false, Collections.emptyList());
+
+        DependencyDownloadResult result = IntegrationProjectDownloadManager.refetchDependencies(
+                projectRoot.toString(), List.of(dep), false);
+
+        assertTrue(result.getFailedDependencies().isEmpty());
+        assertTrue(result.getNoDescriptorDependencies().isEmpty());
+        assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
+    }
+
     private static void deleteRecursively(Path path) throws IOException {
 
         if (path == null || !Files.exists(path)) {


### PR DESCRIPTION
## Purpose

Expose connectors defined within integration project dependencies to the referencing project, and improve the dependency loading and download flow.

Fixes: https://github.com/wso2/mi-vscode/issues/1430

## Changes

### Connector resolution
- Load connectors from dependent integration projects during the connector loading phase, making them accessible in the referencing project

### Dependency download flow
- Update the standard dependency update flow to download only newly added dependencies, avoiding redundant re-downloads
- Add a new resource to refetch integration project dependencies by clearing currently downloaded ones

### Testability improvements
- Parameterize `USER_HOME` in the integration project download flow so tests can run without updating or writing to the actual `USER_HOME` directory

### Error handling
- Simplify error message generation for integration project dependency download failure scenarios

## Tests
- Add tests for loading connectors from dependent integration projects
- Add tests for the updated integration project dependency download flow

Fixes: https://github.com/wso2/mi-vscode/issues/1430 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for refreshing integration project dependencies on demand
  * Enhanced connector discovery to include connectors from dependent projects
  * Improved dependency cache management with automatic cleanup of obsolete artifacts

* **Bug Fixes**
  * Better error aggregation and reporting for failed dependency downloads and descriptor issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->