### PR TITLE
[4.0.0] Skip connector download if already provided by an integration project dependency

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDependencyDownloadResult.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDependencyDownloadResult.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser;
+
+import java.util.List;
+
+/**
+ * Encapsulates the results of connector dependency download operations.
+ * <p>
+ * Contains two lists: connectors that failed to download due to general errors,
+ * and connectors that were skipped because they are already provided by an
+ * integration project dependency.
+ * </p>
+ */
+public class ConnectorDependencyDownloadResult {
+
+    private List<String> failedDependencies;
+    private List<String> fromIntegrationProjectDependencies;
+
+    public ConnectorDependencyDownloadResult(List<String> failedDependencies,
+                                             List<String> fromIntegrationProjectDependencies) {
+        this.failedDependencies = failedDependencies;
+        this.fromIntegrationProjectDependencies = fromIntegrationProjectDependencies;
+    }
+
+    public List<String> getFailedDependencies() {
+        return failedDependencies;
+    }
+
+    public List<String> getFromIntegrationProjectDependencies() {
+        return fromIntegrationProjectDependencies;
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
@@ -82,6 +82,15 @@ public class ConnectorDownloadManager {
         List<String> failedDependencies = new ArrayList<>();
 
         for (DependencyDetails dependency : dependencies) {
+            String failedDependencyId =
+                    dependency.getGroupId() + Constant.HYPHEN + dependency.getArtifact() + Constant.HYPHEN + dependency.getVersion();
+            boolean isFromIntegrationProjectDependency = isConnectorFromIntegrationProjectDependency(dependency.getArtifact());
+            if (isFromIntegrationProjectDependency) {
+                LOGGER.log(Level.WARNING, "Connector " + failedDependencyId +
+                        " is provided by an integration project dependency. Download not allowed.");
+                failedDependencies.add(failedDependencyId);
+                continue;
+            }
             try {
                 File connector = Path.of(downloadDirectory.getAbsolutePath(),
                         dependency.getArtifact() + "-" + dependency.getVersion() + Constant.ZIP_EXTENSION).toFile();
@@ -106,6 +115,16 @@ public class ConnectorDownloadManager {
             }
         }
         return failedDependencies;
+    }
+
+    /**
+     * Returns true if the connector with the given artifact ID is already loaded from an integration
+     * project dependency (i.e. not owned by the current project). 
+     */
+    private static boolean isConnectorFromIntegrationProjectDependency(String artifactId) {
+
+        return ConnectorHolder.getInstance().getConnectors().stream()
+                .anyMatch(c -> artifactId.equalsIgnoreCase(c.getArtifactId()) && !c.isFromProject());
     }
 
     private static void deleteRemovedConnectors(File downloadDirectory, List<DependencyDetails> dependencies,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
@@ -62,6 +62,8 @@ public class ConnectorDownloadManager {
 
     public static ConnectorDependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies) {
 
+        LOGGER.log(Level.INFO, "Starting connector dependency download for project: " + new File(projectPath).getName()
+                + " with " + dependencies.size() + " dependencies");
         String projectId = new File(projectPath).getName() + "_" + Utils.getHash(projectPath);
         File directory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI, Constant.CONNECTORS,
                 projectId).toFile();
@@ -112,6 +114,9 @@ public class ConnectorDownloadManager {
                 failedDependencies.add(dependencyId);
             }
         }
+        LOGGER.log(Level.INFO, "Connector dependency download completed for project: " + new File(projectPath).getName()
+                + ". Failed: " + failedDependencies.size() + ", From integration project dependencies: "
+                + fromIntegrationProjectDependencies.size());
         return new ConnectorDependencyDownloadResult(failedDependencies, fromIntegrationProjectDependencies);
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
@@ -60,7 +60,7 @@ public class ConnectorDownloadManager {
 
     private static final Logger LOGGER = Logger.getLogger(ConnectorDownloadManager.class.getName());
 
-    public static List<String> downloadDependencies(String projectPath, List<DependencyDetails> dependencies) {
+    public static ConnectorDependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies) {
 
         String projectId = new File(projectPath).getName() + "_" + Utils.getHash(projectPath);
         File directory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI, Constant.CONNECTORS,
@@ -80,15 +80,15 @@ public class ConnectorDownloadManager {
 
         deleteRemovedConnectors(downloadDirectory, dependencies, projectPath);
         List<String> failedDependencies = new ArrayList<>();
+        List<String> fromIntegrationProjectDependencies = new ArrayList<>();
 
         for (DependencyDetails dependency : dependencies) {
-            String failedDependencyId =
+            String dependencyId =
                     dependency.getGroupId() + Constant.HYPHEN + dependency.getArtifact() + Constant.HYPHEN + dependency.getVersion();
-            boolean isFromIntegrationProjectDependency = isConnectorFromIntegrationProjectDependency(dependency.getArtifact());
-            if (isFromIntegrationProjectDependency) {
-                LOGGER.log(Level.WARNING, "Connector " + failedDependencyId +
+            if (isConnectorFromIntegrationProjectDependency(dependency.getArtifact())) {
+                LOGGER.log(Level.WARNING, "Connector " + dependencyId +
                         " is provided by an integration project dependency. Download not allowed.");
-                failedDependencies.add(failedDependencyId);
+                fromIntegrationProjectDependencies.add(dependencyId);
                 continue;
             }
             try {
@@ -107,14 +107,12 @@ public class ConnectorDownloadManager {
                             downloadDirectory, Constant.ZIP_EXTENSION_NO_DOT, projectPath);
                 }
             } catch (Exception e) {
-                String failedDependency =
-                        dependency.getGroupId() + "-" + dependency.getArtifact() + "-" + dependency.getVersion();
                 LOGGER.log(Level.WARNING,
-                        "Error occurred while downloading dependency " + failedDependency + ": " + e.getMessage());
-                failedDependencies.add(failedDependency);
+                        "Error occurred while downloading dependency " + dependencyId + ": " + e.getMessage());
+                failedDependencies.add(dependencyId);
             }
         }
-        return failedDependencies;
+        return new ConnectorDependencyDownloadResult(failedDependencies, fromIntegrationProjectDependencies);
     }
 
     /**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
@@ -49,20 +49,19 @@ public class DependencyDownloadManager {
                 pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
         List<DependencyDetails> integrationProjectDependencies =
                 pomDetailsResponse.getDependenciesDetails().getIntegrationProjectDependencies();
-        List<String> failedConnectorDependencies =
+        ConnectorDependencyDownloadResult connectorResult =
                 ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
         Node isVersionedDeployment = pomDetailsResponse.getBuildDetails().getVersionedDeployment();
         boolean isVersionedDeploymentEnabled = isVersionedDeployment != null ?
                 Boolean.parseBoolean(isVersionedDeployment.getValue()) : false;
-        DependencyDownloadResult integrationProjectResult =
+        IntegrationProjectDependencyDownloadResult integrationProjectResult =
                 IntegrationProjectDownloadManager.downloadDependencies(projectPath, integrationProjectDependencies,
                         isVersionedDeploymentEnabled);
 
         StringBuilder errorMessage = new StringBuilder();
-        if (!failedConnectorDependencies.isEmpty()) {
-            String connectorError = "Some connectors were not downloaded: " + String.join(", ", failedConnectorDependencies);
-            LOGGER.log(Level.SEVERE, connectorError);
-            errorMessage.append(connectorError);
+        String connectorErrorMessage = buildConnectorErrorMessage(connectorResult);
+        if (!connectorErrorMessage.isEmpty()) {
+            errorMessage.append(connectorErrorMessage);
         }
 
         String integrationProjectsErrorMessage = buildIntegrationProjectsErrorMessage(integrationProjectResult);
@@ -97,7 +96,7 @@ public class DependencyDownloadManager {
         Node isVersionedDeployment = pomDetailsResponse.getBuildDetails().getVersionedDeployment();
         boolean isVersionedDeploymentEnabled = isVersionedDeployment != null ?
                 Boolean.parseBoolean(isVersionedDeployment.getValue()) : false;
-        DependencyDownloadResult result =
+        IntegrationProjectDependencyDownloadResult result =
                 IntegrationProjectDownloadManager.refetchDependencies(projectPath, integrationProjectDependencies,
                         isVersionedDeploymentEnabled);
 
@@ -110,11 +109,41 @@ public class DependencyDownloadManager {
     }
 
     /**
-     * Builds a human-readable error string from a {@link DependencyDownloadResult},
+     * Builds a human-readable error string from a {@link ConnectorDependencyDownloadResult},
      * logging and concatenating each category of failure. Returns an empty string if
      * there were no failures.
      */
-    private static String buildIntegrationProjectsErrorMessage(DependencyDownloadResult result) {
+    private static String buildConnectorErrorMessage(ConnectorDependencyDownloadResult result) {
+
+        StringBuilder errorMessage = new StringBuilder();
+
+        if (!result.getFailedDependencies().isEmpty()) {
+            String connectorError = "Some connectors were not downloaded: " +
+                    String.join(", ", result.getFailedDependencies());
+            LOGGER.log(Level.SEVERE, connectorError);
+            errorMessage.append(connectorError);
+        }
+
+        if (!result.getFromIntegrationProjectDependencies().isEmpty()) {
+            String integrationProjectError = "Following connectors are provided by integration project dependencies" +
+                    " and cannot be downloaded: " +
+                    String.join(", ", result.getFromIntegrationProjectDependencies());
+            LOGGER.log(Level.SEVERE, integrationProjectError);
+            if (errorMessage.length() > 0) {
+                errorMessage.append(". ");
+            }
+            errorMessage.append(integrationProjectError);
+        }
+
+        return errorMessage.toString();
+    }
+
+    /**
+     * Builds a human-readable error string from a {@link IntegrationProjectDependencyDownloadResult},
+     * logging and concatenating each category of failure. Returns an empty string if
+     * there were no failures.
+     */
+    private static String buildIntegrationProjectsErrorMessage(IntegrationProjectDependencyDownloadResult result) {
 
         StringBuilder errorMessage = new StringBuilder();
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDependencyDownloadResult.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDependencyDownloadResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -17,20 +17,22 @@ package org.eclipse.lemminx.customservice.synapse.parser;
 import java.util.List;
 
 /**
- * Encapsulates the results of dependency download operations.
+ * Encapsulates the results of integration project dependency download operations.
  * <p>
- * Contains two lists: dependencies that failed to download due to general errors,
- * and dependencies that failed due to missing or invalid descriptor.xml files.
+ * Contains three lists: dependencies that failed to download due to general errors,
+ * dependencies that failed due to missing or invalid descriptor.xml files, and
+ * dependencies whose versioning type does not match the current project.
  * </p>
  */
-public class DependencyDownloadResult {
+public class IntegrationProjectDependencyDownloadResult {
 
     private List<String> failedDependencies;
     private List<String> noDescriptorDependencies;
     private List<String> versioningTypeMismatchDependencies;
 
-    public DependencyDownloadResult(List<String> failedDependencies, List<String> noDescriptorDependencies,
-                                    List<String> versioningTypeMismatchDependencies) {
+    public IntegrationProjectDependencyDownloadResult(List<String> failedDependencies,
+                                                      List<String> noDescriptorDependencies,
+                                                      List<String> versioningTypeMismatchDependencies) {
         this.failedDependencies = failedDependencies;
         this.noDescriptorDependencies = noDescriptorDependencies;
         this.versioningTypeMismatchDependencies = versioningTypeMismatchDependencies;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -75,7 +75,8 @@ public class IntegrationProjectDownloadManager {
     public static IntegrationProjectDependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                                boolean isVersionedDeploymentEnabled) {
 
-        LOGGER.log(Level.INFO, "Starting hard refresh of dependencies for project: " + new File(projectPath).getName());
+        LOGGER.log(Level.INFO, "Starting hard refresh of dependencies for project: " + new File(projectPath).getName()
+                + " with " + dependencies.size() + " dependencies");
         return refetchDependencies(projectPath, dependencies, isVersionedDeploymentEnabled,
                 Path.of(System.getProperty(Constant.USER_HOME)));
     }
@@ -184,6 +185,10 @@ public class IntegrationProjectDownloadManager {
         deleteObsoleteDownloadedFiles(downloadDirectory, expectedBaseNames);
         deleteObsoleteExtractedDirs(extractDirectory, expectedBaseNames);
 
+        LOGGER.log(Level.INFO, "Integration project dependency download completed for project: "
+                + new File(projectPath).getName() + ". Failed: " + failedDependencies.size()
+                + ", No descriptor: " + noDescriptorDependencies.size()
+                + ", Version mismatch: " + versioningMismatchDependencies.size());
         return new IntegrationProjectDependencyDownloadResult(failedDependencies, noDescriptorDependencies, versioningMismatchDependencies);
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -72,7 +72,7 @@ public class IntegrationProjectDownloadManager {
      * @param isVersionedDeploymentEnabled indicates if versioned deployment is enabled in the parent project
      * @return a result object containing any dependencies that failed to download or process
      */
-    public static DependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
+    public static IntegrationProjectDependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                                boolean isVersionedDeploymentEnabled) {
 
         LOGGER.log(Level.INFO, "Starting hard refresh of dependencies for project: " + new File(projectPath).getName());
@@ -80,7 +80,7 @@ public class IntegrationProjectDownloadManager {
                 Path.of(System.getProperty(Constant.USER_HOME)));
     }
 
-    public static DependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
+    public static IntegrationProjectDependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                         boolean isVersionedDeploymentEnabled, Path userHome) {
 
         String projectId = new File(projectPath).getName() + UNDERSCORE + Utils.getHash(projectPath);
@@ -120,14 +120,14 @@ public class IntegrationProjectDownloadManager {
      * @param isVersionedDeploymentEnabled indicates if versioned deployment is enabled in the parent project
      * @return a list of dependency identifiers that failed to download or process
      */
-    public static DependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies,
+    public static IntegrationProjectDependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                                 boolean isVersionedDeploymentEnabled) {
 
         return downloadDependencies(projectPath, dependencies, isVersionedDeploymentEnabled,
                 Path.of(System.getProperty(Constant.USER_HOME)));
     }
 
-    public static DependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies,
+    public static IntegrationProjectDependencyDownloadResult downloadDependencies(String projectPath, List<DependencyDetails> dependencies,
                                                          boolean isVersionedDeploymentEnabled, Path userHome) {
 
         String projectId = new File(projectPath).getName() + UNDERSCORE + Utils.getHash(projectPath);
@@ -184,7 +184,7 @@ public class IntegrationProjectDownloadManager {
         deleteObsoleteDownloadedFiles(downloadDirectory, expectedBaseNames);
         deleteObsoleteExtractedDirs(extractDirectory, expectedBaseNames);
 
-        return new DependencyDownloadResult(failedDependencies, noDescriptorDependencies, versioningMismatchDependencies);
+        return new IntegrationProjectDependencyDownloadResult(failedDependencies, noDescriptorDependencies, versioningMismatchDependencies);
     }
 
     /**

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/downloader/ConnectorDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/downloader/ConnectorDownloadManagerTest.java
@@ -52,6 +52,9 @@ public class ConnectorDownloadManagerTest {
     @AfterEach
     void tearDown() {
         ConnectorHolder.getInstance().clearConnectors();
+        if (utilsMock != null) {
+            utilsMock.close();
+        }
     }
 
     @Test
@@ -64,7 +67,6 @@ public class ConnectorDownloadManagerTest {
         List<DependencyDetails>
                 connectorDependencies = pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
         ConnectorDependencyDownloadResult result = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
-        utilsMock.close();
 
         assertEquals(0, result.getFailedDependencies().size());
         assertEquals(0, result.getFromIntegrationProjectDependencies().size());
@@ -87,7 +89,6 @@ public class ConnectorDownloadManagerTest {
                 pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
 
         ConnectorDependencyDownloadResult result = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
-        utilsMock.close();
 
         assertTrue(result.getFromIntegrationProjectDependencies().stream().anyMatch(dep -> dep.contains("mi-connector-http")),
                 "Connector from integration project dependency should be marked as failed");
@@ -103,7 +104,6 @@ public class ConnectorDownloadManagerTest {
         List<DependencyDetails>
                 connectorDependencies = pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
         ConnectorDependencyDownloadResult result = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
-        utilsMock.close();
 
         assertFalse(result.getFailedDependencies().isEmpty());
     }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/downloader/ConnectorDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/downloader/ConnectorDownloadManagerTest.java
@@ -18,6 +18,7 @@ import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
 import org.eclipse.lemminx.customservice.synapse.parser.ConnectorDownloadManager;
 import org.eclipse.lemminx.customservice.synapse.parser.DependencyDetails;
+import org.eclipse.lemminx.customservice.synapse.parser.ConnectorDependencyDownloadResult;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPageDetailsResponse;
 import org.eclipse.lemminx.customservice.synapse.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
@@ -62,10 +63,11 @@ public class ConnectorDownloadManagerTest {
         getPomDetails(projectPath, pomDetailsResponse);
         List<DependencyDetails>
                 connectorDependencies = pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
-        List<String> failedDependencies = connectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
+        ConnectorDependencyDownloadResult result = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
         utilsMock.close();
 
-        assertEquals(0, failedDependencies.size());
+        assertEquals(0, result.getFailedDependencies().size());
+        assertEquals(0, result.getFromIntegrationProjectDependencies().size());
     }
 
     @Test
@@ -84,10 +86,10 @@ public class ConnectorDownloadManagerTest {
         List<DependencyDetails> connectorDependencies =
                 pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
 
-        List<String> failedDependencies = connectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
+        ConnectorDependencyDownloadResult result = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
         utilsMock.close();
 
-        assertTrue(failedDependencies.stream().anyMatch(dep -> dep.contains("mi-connector-http")),
+        assertTrue(result.getFromIntegrationProjectDependencies().stream().anyMatch(dep -> dep.contains("mi-connector-http")),
                 "Connector from integration project dependency should be marked as failed");
     }
 
@@ -100,9 +102,9 @@ public class ConnectorDownloadManagerTest {
         getPomDetails(projectPath, pomDetailsResponse);
         List<DependencyDetails>
                 connectorDependencies = pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
-        List<String> failedDependencies = connectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
+        ConnectorDependencyDownloadResult result = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
         utilsMock.close();
 
-        assertFalse(failedDependencies.isEmpty());
+        assertFalse(result.getFailedDependencies().isEmpty());
     }
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/downloader/ConnectorDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/downloader/ConnectorDownloadManagerTest.java
@@ -14,10 +14,13 @@
 
 package org.eclipse.lemminx.synapse.connector.downloader;
 
+import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
+import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
 import org.eclipse.lemminx.customservice.synapse.parser.ConnectorDownloadManager;
 import org.eclipse.lemminx.customservice.synapse.parser.DependencyDetails;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPageDetailsResponse;
 import org.eclipse.lemminx.customservice.synapse.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -29,6 +32,7 @@ import java.util.List;
 import static org.eclipse.lemminx.customservice.synapse.parser.pom.PomParser.getPomDetails;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mockStatic;
 
@@ -41,6 +45,12 @@ public class ConnectorDownloadManagerTest {
     void setUp() {
         connectorDownloadManager = new ConnectorDownloadManager();
         utilsMock = mockStatic(Utils.class);
+        ConnectorHolder.getInstance().clearConnectors();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ConnectorHolder.getInstance().clearConnectors();
     }
 
     @Test
@@ -56,6 +66,29 @@ public class ConnectorDownloadManagerTest {
         utilsMock.close();
 
         assertEquals(0, failedDependencies.size());
+    }
+
+    @Test
+    void downloadConnectorsFromIntegrationProjectDependency() {
+        String path = ConnectorDownloadManagerTest.class.getResource("/synapse/pom.parser/test_pom_parser").getPath();
+        String projectPath = new File(path).getAbsolutePath();
+
+        // Simulate a connector already loaded from an integration project dependency (fromProject = false)
+        Connector dependencyConnector = new Connector();
+        dependencyConnector.setArtifactId("mi-connector-http");
+        dependencyConnector.setFromProject(false);
+        ConnectorHolder.getInstance().addConnector(dependencyConnector);
+
+        OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
+        getPomDetails(projectPath, pomDetailsResponse);
+        List<DependencyDetails> connectorDependencies =
+                pomDetailsResponse.getDependenciesDetails().getConnectorDependencies();
+
+        List<String> failedDependencies = connectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
+        utilsMock.close();
+
+        assertTrue(failedDependencies.stream().anyMatch(dep -> dep.contains("mi-connector-http")),
+                "Connector from integration project dependency should be marked as failed");
     }
 
     @Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.lemminx.synapse.parser;
 
 import org.eclipse.lemminx.customservice.synapse.parser.DependencyDetails;
-import org.eclipse.lemminx.customservice.synapse.parser.DependencyDownloadResult;
+import org.eclipse.lemminx.customservice.synapse.parser.IntegrationProjectDependencyDownloadResult;
 import org.eclipse.lemminx.customservice.synapse.parser.IntegrationProjectDownloadManager;
 import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 import org.eclipse.lemminx.customservice.synapse.utils.Utils;
@@ -84,7 +84,7 @@ public class IntegrationProjectDownloadManagerTest {
     @Test
     public void testEmptyDependencies_allResultListsEmptyAndDirectoriesCreated() {
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), Collections.emptyList(), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
@@ -117,7 +117,7 @@ public class IntegrationProjectDownloadManagerTest {
             utilsMock.when(() -> Utils.getHash(any())).thenCallRealMethod();
             utilsMock.when(() -> Utils.deleteDirectory(any())).thenCallRealMethod();
 
-            DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+            IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                     projectRoot.toString(), List.of(dep), false, tempHome);
 
             assertEquals(1, result.getFailedDependencies().size());
@@ -147,7 +147,7 @@ public class IntegrationProjectDownloadManagerTest {
         Files.createDirectories(repoDir);
         createZipWithoutDescriptor(repoDir, dep.getArtifact() + "-" + dep.getVersion() + ".car");
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertEquals(1, result.getNoDescriptorDependencies().size());
@@ -169,7 +169,7 @@ public class IntegrationProjectDownloadManagerTest {
         // Plant a .car with versionedDeployment=true in the local repo; parent has false
         plantInLocalRepo(dep, true, Collections.emptyList());
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertEquals(1, result.getVersioningTypeMismatchDependencies().size());
@@ -196,7 +196,7 @@ public class IntegrationProjectDownloadManagerTest {
         Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
@@ -222,7 +222,7 @@ public class IntegrationProjectDownloadManagerTest {
         Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(rootDep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
@@ -255,7 +255,7 @@ public class IntegrationProjectDownloadManagerTest {
         long lastModifiedBefore = existingCar.toFile().lastModified();
 
         // Nothing planted in local repo — if the code tries to fetch it would find nothing
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
@@ -287,7 +287,7 @@ public class IntegrationProjectDownloadManagerTest {
         long lastModifiedBefore = existingZip.toFile().lastModified();
 
         // Nothing planted in local repo — if the code tries to fetch it would find nothing
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
@@ -574,7 +574,7 @@ public class IntegrationProjectDownloadManagerTest {
         // newDep: fetched fresh from local repo (pre-extraction .car)
         plantInLocalRepo(newDep, false, Collections.emptyList());
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(existingDep, newDep), false, tempHome);
 
         // Extracted: existingDep's dir must be preserved
@@ -662,7 +662,7 @@ public class IntegrationProjectDownloadManagerTest {
         Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(dep, dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
@@ -691,7 +691,7 @@ public class IntegrationProjectDownloadManagerTest {
         Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.downloadDependencies(
                 projectRoot.toString(), List.of(goodDep, badDep), false, tempHome);
 
         assertEquals(1, result.getFailedDependencies().size());
@@ -830,7 +830,7 @@ public class IntegrationProjectDownloadManagerTest {
         Path downloadDir = resolveProjectBaseDir().resolve(Constant.DOWNLOADED);
         assertFalse(downloadDir.toFile().exists(), "downloadDir must not exist before the call");
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.refetchDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.refetchDependencies(
                 projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());
@@ -1013,7 +1013,7 @@ public class IntegrationProjectDownloadManagerTest {
         DependencyDetails dep = makeDep("com.example", "dep-a", "1.0.0", "car");
         plantInLocalRepo(dep, false, Collections.emptyList());
 
-        DependencyDownloadResult result = IntegrationProjectDownloadManager.refetchDependencies(
+        IntegrationProjectDependencyDownloadResult result = IntegrationProjectDownloadManager.refetchDependencies(
                 projectRoot.toString(), List.of(dep), false, tempHome);
 
         assertTrue(result.getFailedDependencies().isEmpty());


### PR DESCRIPTION
## Purpose
When adding a new connector, if the connector is already included as part of an integration project dependency, the download is skipped and an appropriate message is shown to the user.

Fixes: https://github.com/wso2/mi-vscode/issues/1442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Dependency download errors now tracked separately, distinguishing between download failures and integration project dependency conflicts.
- Enhanced logging for dependency download operations, including operation counts for failed and skipped dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->