### PR TITLE
Introduce support to override connector dependencies in descriptor.yml

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -952,6 +952,9 @@ public class SynapseLanguageService implements ISynapseLanguageService {
             try {
                 ConnectorConfigService.updateDependencyOverride(projectUri, request);
                 return true;
+            } catch (IllegalArgumentException e) {
+                log.log(Level.WARNING, "Invalid request to updateConnectorDependencyOverride: " + e.getMessage());
+                return false;
             } catch (Exception e) {
                 log.log(Level.SEVERE, "Failed to update connector dependency override: " + e.getMessage(), e);
                 return false;
@@ -967,6 +970,9 @@ public class SynapseLanguageService implements ISynapseLanguageService {
             try {
                 ConnectorConfigService.resetDependencyOverrides(projectUri, request);
                 return true;
+            } catch (IllegalArgumentException e) {
+                log.log(Level.WARNING, "Invalid request to resetConnectorDependencyOverrides: " + e.getMessage());
+                return false;
             } catch (Exception e) {
                 log.log(Level.SEVERE, "Failed to reset connector dependency overrides: " + e.getMessage(), e);
                 return false;
@@ -981,6 +987,9 @@ public class SynapseLanguageService implements ISynapseLanguageService {
             try {
                 ConnectorConfigService.updateConnectorFlags(projectUri, request);
                 return true;
+            } catch (IllegalArgumentException e) {
+                log.log(Level.WARNING, "Invalid request to updateConnectorFlags: " + e.getMessage());
+                return false;
             } catch (Exception e) {
                 log.log(Level.SEVERE, "Failed to update connector flags: " + e.getMessage(), e);
                 return false;
@@ -995,6 +1004,9 @@ public class SynapseLanguageService implements ISynapseLanguageService {
             try {
                 ConnectorConfigService.updateGlobalConnectorFlags(projectUri, request);
                 return true;
+            } catch (IllegalArgumentException e) {
+                log.log(Level.WARNING, "Invalid request to updateGlobalConnectorFlags: " + e.getMessage());
+                return false;
             } catch (Exception e) {
                 log.log(Level.SEVERE, "Failed to update root connector config: " + e.getMessage(), e);
                 return false;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -100,6 +100,14 @@ import org.eclipse.lemminx.customservice.synapse.parser.config.ConfigParser;
 import org.eclipse.lemminx.customservice.synapse.parser.config.ConfigurableEntry;
 import org.eclipse.lemminx.customservice.synapse.parser.pom.PomParser;
 import org.eclipse.lemminx.customservice.synapse.parser.ConnectorDownloadManager;
+import org.eclipse.lemminx.customservice.synapse.parser.DependencyDetails;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorConfigService;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorDependencyRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorDependencyResponse;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ResetConnectorDependencyRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorDependencyRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorFlagsRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateRootConfigRequest;
 import org.eclipse.lemminx.customservice.synapse.resourceFinder.AbstractResourceFinder;
 import org.eclipse.lemminx.customservice.synapse.resourceFinder.ArtifactFileScanner;
 import org.eclipse.lemminx.customservice.synapse.resourceFinder.RegistryFileScanner;
@@ -926,6 +934,78 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     public CompletableFuture<DependencyStatusResponse> getDependencyStatusList() {
 
         return CompletableFuture.supplyAsync(() -> DependencyDownloadManager.getDependencyStatusList(projectUri));
+    }
+
+    @Override
+    public CompletableFuture<ConnectorDependencyResponse> getConnectorDependencies(
+            ConnectorDependencyRequest request) {
+
+        return CompletableFuture.supplyAsync(() ->
+                ConnectorConfigService.buildDependencyResponse(projectUri, request.connectorArtifactId));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> updateConnectorDependencyOverride(
+            UpdateConnectorDependencyRequest request) {
+
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                ConnectorConfigService.updateDependencyOverride(projectUri, request);
+                return true;
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Failed to update connector dependency override: " + e.getMessage(), e);
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Boolean> resetConnectorDependencyOverrides(
+            ResetConnectorDependencyRequest request) {
+
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                ConnectorConfigService.resetDependencyOverrides(projectUri, request);
+                return true;
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Failed to reset connector dependency overrides: " + e.getMessage(), e);
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Boolean> updateConnectorFlags(UpdateConnectorFlagsRequest request) {
+
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                ConnectorConfigService.updateConnectorFlags(projectUri, request);
+                return true;
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Failed to update connector flags: " + e.getMessage(), e);
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Boolean> updateRootConfig(UpdateRootConfigRequest request) {
+
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                ConnectorConfigService.updateRootConfig(projectUri, request);
+                return true;
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Failed to update root connector config: " + e.getMessage(), e);
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void initConnectorConfig(ConnectorDependencyRequest request) {
+
+        ConnectorConfigService.initIfAbsent(projectUri);
     }
 
     @Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -107,7 +107,7 @@ import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.Connecto
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ResetConnectorDependencyRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorDependencyRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorFlagsRequest;
-import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateRootConfigRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateGlobalConnectorFlagsRequest;
 import org.eclipse.lemminx.customservice.synapse.resourceFinder.AbstractResourceFinder;
 import org.eclipse.lemminx.customservice.synapse.resourceFinder.ArtifactFileScanner;
 import org.eclipse.lemminx.customservice.synapse.resourceFinder.RegistryFileScanner;
@@ -989,11 +989,11 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateRootConfig(UpdateRootConfigRequest request) {
+    public CompletableFuture<Boolean> updateGlobalConnectorFlags(UpdateGlobalConnectorFlagsRequest request) {
 
         return CompletableFuture.supplyAsync(() -> {
             try {
-                ConnectorConfigService.updateRootConfig(projectUri, request);
+                ConnectorConfigService.updateGlobalConnectorFlags(projectUri, request);
                 return true;
             } catch (Exception e) {
                 log.log(Level.SEVERE, "Failed to update root connector config: " + e.getMessage(), e);
@@ -1059,9 +1059,8 @@ public class SynapseLanguageService implements ISynapseLanguageService {
 
         return CompletableFuture.supplyAsync(() -> ConnectorDownloadManager.downloadDriverForConnector(
                 projectUri,
-                request.getGroupId(),
-                request.getArtifactId(),
-                request.getVersion()
+                request.getConnectorName(),
+                request.getConnectionType()
                 ));
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
@@ -71,6 +71,12 @@ import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.MCPToolReq
 import org.eclipse.lemminx.customservice.synapse.mediatorService.pojo.MCPToolResponse;
 import org.eclipse.lemminx.customservice.synapse.parser.ConfigDetails;
 import org.eclipse.lemminx.customservice.synapse.parser.DependencyStatusResponse;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorDependencyRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorDependencyResponse;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ResetConnectorDependencyRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorDependencyRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorFlagsRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateRootConfigRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.DeployPluginDetails;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPageDetailsResponse;
 import org.eclipse.lemminx.customservice.synapse.parser.UpdateConfigRequest;
@@ -99,6 +105,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Either3;
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 
@@ -319,12 +326,30 @@ public interface ISynapseLanguageService {
 
     @JsonRequest
     CompletableFuture<List<List<Object>>> getInputOutputMappings(MappingsGenRequestParams param);
-  
+
     @JsonRequest
     CompletableFuture<MCPToolResponse> getMCPTools(MCPToolRequest param);
 
     @JsonRequest
     CompletableFuture<Either<ConnectorInfoResponse, String>> resolveConnector(UpdateDependencyRequest request);
+
+    @JsonRequest
+    CompletableFuture<ConnectorDependencyResponse> getConnectorDependencies(ConnectorDependencyRequest request);
+
+    @JsonRequest
+    CompletableFuture<Boolean> updateConnectorDependencyOverride(UpdateConnectorDependencyRequest request);
+
+    @JsonRequest
+    CompletableFuture<Boolean> resetConnectorDependencyOverrides(ResetConnectorDependencyRequest request);
+
+    @JsonRequest
+    CompletableFuture<Boolean> updateConnectorFlags(UpdateConnectorFlagsRequest request);
+
+    @JsonRequest
+    CompletableFuture<Boolean> updateRootConfig(UpdateRootConfigRequest request);
+
+    @JsonNotification
+    void initConnectorConfig(ConnectorDependencyRequest request);
 
     @JsonRequest
     CompletableFuture<ConnectorDetails> isDuplicateConnector(ConnectorDetails request);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/ISynapseLanguageService.java
@@ -76,7 +76,7 @@ import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.Connecto
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ResetConnectorDependencyRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorDependencyRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorFlagsRequest;
-import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateRootConfigRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateGlobalConnectorFlagsRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.DeployPluginDetails;
 import org.eclipse.lemminx.customservice.synapse.parser.OverviewPageDetailsResponse;
 import org.eclipse.lemminx.customservice.synapse.parser.UpdateConfigRequest;
@@ -346,7 +346,7 @@ public interface ISynapseLanguageService {
     CompletableFuture<Boolean> updateConnectorFlags(UpdateConnectorFlagsRequest request);
 
     @JsonRequest
-    CompletableFuture<Boolean> updateRootConfig(UpdateRootConfigRequest request);
+    CompletableFuture<Boolean> updateGlobalConnectorFlags(UpdateGlobalConnectorFlagsRequest request);
 
     @JsonNotification
     void initConnectorConfig(ConnectorDependencyRequest request);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/driver/DriverDownloadRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/driver/DriverDownloadRequest.java
@@ -19,42 +19,31 @@ package org.eclipse.lemminx.customservice.synapse.driver;
  */
 public class DriverDownloadRequest {
 
-    private String groupId;
-    private String artifactId;
-    private String version;
+    private String connectorName;
+    private String connectionType;
 
     public DriverDownloadRequest() {
-        
     }
 
-    public DriverDownloadRequest(String groupId,String artifactId,String version) {
-
-        this.groupId=groupId;
-        this.artifactId=artifactId;
-        this.version=version;
+    public DriverDownloadRequest(String connectorName, String connectionType) {
+        this.connectorName = connectorName;
+        this.connectionType = connectionType;
     }
 
-    public String getGroupId() {
-        return groupId;
+    public String getConnectorName() {
+        return connectorName;
     }
 
-    public void setArtifactId(String artifactId) {
-        this.artifactId = artifactId;
+    public void setConnectorName(String connectorName) {
+        this.connectorName = connectorName;
     }
 
-    public String getArtifactId() {
-        return artifactId;
+    public String getConnectionType() {
+        return connectionType;
     }
 
-    public void setGroupId(String groupId) {
-        this.groupId = groupId;
-    }
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
+    public void setConnectionType(String connectionType) {
+        this.connectionType = connectionType;
     }
 
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
@@ -172,12 +172,38 @@ public class ConnectorDownloadManager {
     }
 
     /**
+     * Resolves a {@link Connector} by short name, display name, or artifact ID.
+     * {@link ConnectorHolder#getConnector} only matches by name/displayName; this method
+     * adds an artifact-ID fallback so callers that pass the Maven artifact ID still succeed.
+     *
+     * @return the matching connector, or {@code null} if not found
+     */
+    private static Connector resolveConnector(String connectorName, ConnectorHolder holder) {
+
+        Connector connector = holder.getConnector(connectorName);
+        if (connector != null) {
+            return connector;
+        }
+        // Fallback: match by artifactId (e.g. "mi-connector-db")
+        for (Connector c : new ArrayList<>(holder.getConnectors())) {
+            if (connectorName.equalsIgnoreCase(c.getArtifactId())) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Downloads the driver JAR for a specific connector and connection type by parsing the descriptor.yml file.
      */
     public static String downloadDriverForConnector(String projectPath, String connectorName, String connectionType) {
         try {
             ConnectorHolder connectorHolder = ConnectorHolder.getInstance();
-            Connector connector = connectorHolder.getConnector(connectorName);
+            Connector connector = resolveConnector(connectorName, connectorHolder);
+            if (connector == null) {
+                LOGGER.log(Level.SEVERE, "Connector not found in holder: " + connectorName);
+                return null;
+            }
 
             String projectId = new File(projectPath).getName() + "_" + Utils.getHash(projectPath);
             File connectorsDirectory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
@@ -207,7 +233,7 @@ public class ConnectorDownloadManager {
                 ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
                 descriptorData = yamlMapper.readValue(inputStream, Map.class);
             } catch (IOException e) {
-                LOGGER.log(Level.SEVERE, "Error reading descriptor.yml: " + e.getMessage());
+                LOGGER.log(Level.SEVERE, "Error reading descriptor.yml", e);
                 return null;
             }
 
@@ -217,8 +243,13 @@ public class ConnectorDownloadManager {
                 return null;
             }
 
+            // Derive the canonical Maven artifact ID from the loaded connector object
+            String canonicalArtifactId = connector.getArtifactId() != null && !connector.getArtifactId().isBlank()
+                    ? connector.getArtifactId()
+                    : connectorName;
+
             // Check global/connector-level omitAllDrivers before reading coordinates
-            if (ConnectorConfigService.isOmitAllDrivers(projectPath, connectorName)) {
+            if (ConnectorConfigService.isOmitAllDrivers(projectPath, canonicalArtifactId)) {
                 LOGGER.log(Level.INFO, "All drivers for " + connectorName
                         + " are omitted via connector-config.json (omitAllDrivers); skipping download.");
                 return null;
@@ -230,7 +261,17 @@ public class ConnectorDownloadManager {
 
             // Apply any override from connector-config.json
             DependencyOverride override = ConnectorConfigService.findOverrideByConnectorNameAndConnectionType(
-                    projectPath, connectorName, connectionType);
+                    projectPath, canonicalArtifactId, connectionType);
+
+            if (override != null && !StringUtils.isBlank(override.localPath)) {
+                File localJar = new File(override.localPath);
+                if (localJar.exists() && localJar.isFile()) {
+                    LOGGER.log(Level.INFO, "Using local driver JAR override: " + override.localPath);
+                    return override.localPath;
+                }
+                LOGGER.log(Level.SEVERE, "Local driver JAR not found at: " + override.localPath);
+                return null;
+            }
             if (override != null) {
                 if (Boolean.TRUE.equals(override.omit)) {
                     LOGGER.log(Level.INFO, "Driver for " + connectorName + "/" + connectionType
@@ -284,7 +325,7 @@ public class ConnectorDownloadManager {
             LOGGER.log(Level.SEVERE, "IOException occurred while downloading driver: " + e.getMessage());
             return null;
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Error while downloading driver: " + e.getMessage());
+            LOGGER.log(Level.SEVERE, "Error while downloading driver: " + e);
             return null;
         }
     }
@@ -420,9 +461,12 @@ public class ConnectorDownloadManager {
         String artifactId = null;
         String version = null;
         if (StringUtils.isBlank(driverPath)) {
-            ConnectorHolder connectorHolder;
-            connectorHolder = ConnectorHolder.getInstance();
-            Connector connector = connectorHolder.getConnector(connectorName);
+            ConnectorHolder connectorHolder = ConnectorHolder.getInstance();
+            Connector connector = resolveConnector(connectorName, connectorHolder);
+            if (connector == null) {
+                LOGGER.log(Level.SEVERE, "Connector not found in holder: " + connectorName);
+                return null;
+            }
 
             String connectorPath = connector.getExtractedConnectorPath();
             File connectorDirectory = Path.of(connectorPath).toFile();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
@@ -206,16 +206,12 @@ public class ConnectorDownloadManager {
             }
 
             String projectId = new File(projectPath).getName() + "_" + Utils.getHash(projectPath);
-            File connectorsDirectory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
-                    Constant.CONNECTORS, projectId, Constant.EXTRACTED).toFile();
-
-            if (!connectorsDirectory.exists() || !connectorsDirectory.isDirectory()) {
-                LOGGER.log(Level.SEVERE,
-                        "Connectors directory does not exist: " + connectorsDirectory.getAbsolutePath());
-                return null;
-            }
 
             String connectorPath = connector.getExtractedConnectorPath();
+            if (StringUtils.isBlank(connectorPath)) {
+                LOGGER.log(Level.SEVERE, "Extracted connector path is not set for connector: " + connector.getName());
+                return null;
+            }
             File connectorDirectory = Path.of(connectorPath).toFile();
             if (!connectorDirectory.exists() || !connectorDirectory.isDirectory()) {
                 LOGGER.log(Level.SEVERE, "Connector directory does not exist: " + connectorDirectory.getAbsolutePath());
@@ -322,10 +318,10 @@ public class ConnectorDownloadManager {
             return expectedDriverFile.getAbsolutePath();
 
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "IOException occurred while downloading driver: " + e.getMessage());
+            LOGGER.log(Level.SEVERE, "IOException occurred while downloading driver: " + e.getMessage(), e);
             return null;
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Error while downloading driver: " + e);
+            LOGGER.log(Level.SEVERE, "Error while downloading driver: " + e.getMessage(), e);
             return null;
         }
     }
@@ -469,6 +465,10 @@ public class ConnectorDownloadManager {
             }
 
             String connectorPath = connector.getExtractedConnectorPath();
+            if (StringUtils.isBlank(connectorPath)) {
+                LOGGER.log(Level.SEVERE, "Extracted connector path is not set for connector: " + connector.getName());
+                return null;
+            }
             File connectorDirectory = Path.of(connectorPath).toFile();
             if (!connectorDirectory.exists() || !connectorDirectory.isDirectory()) {
                 LOGGER.log(Level.SEVERE, "Connector directory does not exist: " + connectorDirectory.getAbsolutePath());

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/ConnectorDownloadManager.java
@@ -28,6 +28,8 @@ import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
 import org.eclipse.lemminx.customservice.synapse.driver.DriverGroupIdLookup;
 import org.eclipse.lemminx.customservice.synapse.driver.DriverMavenCoordinatesResponse;
 import org.eclipse.lemminx.customservice.synapse.mediator.TryOutConstants;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorConfigService;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.DependencyOverride;
 import org.eclipse.lemminx.customservice.synapse.schemagen.json.JSONArray;
 import org.eclipse.lemminx.customservice.synapse.schemagen.json.JSONObject;
 import org.eclipse.lemminx.customservice.synapse.utils.Constant;
@@ -170,63 +172,121 @@ public class ConnectorDownloadManager {
     }
 
     /**
-     * Downloads the driver JAR for a specific connector and add to local maven repo.
+     * Downloads the driver JAR for a specific connector and connection type by parsing the descriptor.yml file.
      */
-    public static String downloadDriverForConnector(String projectPath, String groupId, String artifactId,
-                                                    String version) {
-
-        if (StringUtils.isAnyBlank(groupId, artifactId, version)) {
-            LOGGER.log(Level.SEVERE, "Invalid Maven coordinates");
-            return null;
-        }
-
+    public static String downloadDriverForConnector(String projectPath, String connectorName, String connectionType) {
         try {
-            // 1. Try loading from local Maven repo
-            File localDriverFile = getDriverFromLocalRepo(groupId, artifactId, version);
-            if (localDriverFile != null) {
-                return localDriverFile.getAbsolutePath();
-            }
+            ConnectorHolder connectorHolder = ConnectorHolder.getInstance();
+            Connector connector = connectorHolder.getConnector(connectorName);
 
-            // 2. Prepare temp directory for download
             String projectId = new File(projectPath).getName() + "_" + Utils.getHash(projectPath);
-            File driversDirectory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
-                    Constant.CONNECTORS, projectId, Constant.DRIVERS).toFile();
+            File connectorsDirectory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+                    Constant.CONNECTORS, projectId, Constant.EXTRACTED).toFile();
 
-            if (!driversDirectory.exists() && !driversDirectory.mkdirs()) {
-                LOGGER.log(Level.SEVERE, "Failed to create driver directory: " + driversDirectory.getAbsolutePath());
+            if (!connectorsDirectory.exists() || !connectorsDirectory.isDirectory()) {
+                LOGGER.log(Level.SEVERE,
+                        "Connectors directory does not exist: " + connectorsDirectory.getAbsolutePath());
                 return null;
             }
 
-            // 3. Check if driver already exists in temp
-            File tempDriverFile = new File(driversDirectory, artifactId + "-" + version + Constant.JAR_EXTENSION);
-            if (!tempDriverFile.exists()) {
-                // Download only if not present
-                LOGGER.log(Level.INFO, "Downloading driver from Maven repository...");
-                Utils.downloadConnector(groupId, artifactId, version, driversDirectory, Constant.JAR_EXTENSION_NO_DOT,projectPath);
-            } else {
-                LOGGER.log(Level.INFO, "Driver already exists in temp: " + tempDriverFile.getAbsolutePath());
+            String connectorPath = connector.getExtractedConnectorPath();
+            File connectorDirectory = Path.of(connectorPath).toFile();
+            if (!connectorDirectory.exists() || !connectorDirectory.isDirectory()) {
+                LOGGER.log(Level.SEVERE, "Connector directory does not exist: " + connectorDirectory.getAbsolutePath());
+                return null;
             }
 
-            // 4. Validate driver file exists
-            if (!tempDriverFile.exists() || !tempDriverFile.isFile()) {
-                String msg = "Driver JAR not found after attempted download: " + tempDriverFile.getAbsolutePath();
-                LOGGER.log(Level.SEVERE, msg);
-                throw new IOException(msg);
+            File descriptorFile = new File(connectorDirectory, Constant.DESCRIPTOR_FILE);
+            if (!descriptorFile.exists()) {
+                LOGGER.log(Level.SEVERE, "descriptor.yml not found in connector: " + connectorName);
+                return null;
             }
 
-            // 5. Add to local repo
-            String driverPath = addDriverToLocalRepo(groupId, artifactId, version, tempDriverFile.getAbsolutePath(),
-                    projectPath);
-            LOGGER.log(Level.INFO, "Driver added to local repo: " + driverPath);
-            return driverPath;
+            Map<String, Object> descriptorData;
+            try (InputStream inputStream = new FileInputStream(descriptorFile)) {
+                ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+                descriptorData = yamlMapper.readValue(inputStream, Map.class);
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Error reading descriptor.yml: " + e.getMessage());
+                return null;
+            }
+
+            Map<String, Object> driverInfo = findDriverForConnectionType(descriptorData, connectionType);
+            if (driverInfo == null) {
+                LOGGER.log(Level.SEVERE, "No driver found for connection type: " + connectionType);
+                return null;
+            }
+
+            // Check global/connector-level omitAllDrivers before reading coordinates
+            if (ConnectorConfigService.isOmitAllDrivers(projectPath, connectorName)) {
+                LOGGER.log(Level.INFO, "All drivers for " + connectorName
+                        + " are omitted via connector-config.json (omitAllDrivers); skipping download.");
+                return null;
+            }
+
+            String groupId = (String) driverInfo.get(Constant.GROUP_ID_KEY);
+            String artifactId = (String) driverInfo.get(Constant.ARTIFACT_ID_KEY);
+            String version = (String) driverInfo.get(Constant.VERSION_KEY);
+
+            // Apply any override from connector-config.json
+            DependencyOverride override = ConnectorConfigService.findOverrideByConnectorNameAndConnectionType(
+                    projectPath, connectorName, connectionType);
+            if (override != null) {
+                if (Boolean.TRUE.equals(override.omit)) {
+                    LOGGER.log(Level.INFO, "Driver for " + connectorName + "/" + connectionType
+                            + " is omitted via connector-config.json; skipping download.");
+                    return null;
+                }
+                if (!StringUtils.isBlank(override.groupId)) groupId = override.groupId;
+                if (!StringUtils.isBlank(override.artifactId)) artifactId = override.artifactId;
+                if (!StringUtils.isBlank(override.version)) {
+                    LOGGER.log(Level.INFO, "Overriding driver version for " + connectorName + "/"
+                            + connectionType + " from " + version + " to " + override.version
+                            + " as per connector-config.json.");
+                    version = override.version;
+                }
+            }
+
+            if (StringUtils.isAnyBlank(groupId, artifactId, version)) {
+                LOGGER.log(Level.SEVERE, "Invalid driver coordinates in descriptor");
+                return null;
+            }
+
+            File driversDirectory = Path.of(System.getProperty(Constant.USER_HOME), Constant.WSO2_MI,
+                    Constant.CONNECTORS, projectId, Constant.DRIVERS).toFile();
+            if (!driversDirectory.exists()) {
+                driversDirectory.mkdirs();
+            }
+
+            File driverFile = new File(driversDirectory, artifactId + "-" + version + Constant.JAR_EXTENSION);
+            if (driverFile.exists()) {
+                LOGGER.log(Level.INFO, "Driver already exists: " + driverFile.getAbsolutePath());
+                return driverFile.getAbsolutePath();
+            }
+
+            File localDriverFile = getDriverFromLocalRepo(groupId, artifactId, version);
+            if (localDriverFile != null) {
+                copyFile(localDriverFile.getPath(), driversDirectory.getPath());
+                return new File(driversDirectory, localDriverFile.getName()).getAbsolutePath();
+            }
+
+            Utils.downloadConnector(groupId, artifactId, version, driversDirectory, Constant.JAR_EXTENSION_NO_DOT, projectPath);
+
+            File expectedDriverFile = new File(driversDirectory, artifactId + "-" + version + Constant.JAR_EXTENSION);
+            if (!expectedDriverFile.exists() || !expectedDriverFile.isFile()) {
+                throw new IOException("Failed to download or locate driver file: " + expectedDriverFile.getName());
+            }
+
+            LOGGER.log(Level.INFO, "Driver downloaded: " + expectedDriverFile.getAbsolutePath());
+            return expectedDriverFile.getAbsolutePath();
 
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "IO error while downloading driver: " + e.getMessage(), e);
+            LOGGER.log(Level.SEVERE, "IOException occurred while downloading driver: " + e.getMessage());
+            return null;
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Unexpected error while downloading driver: " + e.getMessage(), e);
+            LOGGER.log(Level.SEVERE, "Error while downloading driver: " + e.getMessage());
+            return null;
         }
-
-        return null;
     }
 
     /**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfig.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Root model for {@code src/main/wso2mi/connector-config.json}.
+ * Root model for {@code src/main/wso2mi/resources/connectors/connector-config.json}.
  * Key in {@code connectors} is the connector Maven artifactId (e.g. "mi-connector-file").
  */
 public class ConnectorConfig {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfig.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Root model for {@code src/main/wso2mi/connector-config.json}.
+ * Key in {@code connectors} is the connector Maven artifactId (e.g. "mi-connector-file").
+ */
+public class ConnectorConfig {
+
+    public String version;
+
+    /**
+     * When true, no driver JARs will be packed into the CAR for any connector.
+     * Overrides all per-connector and per-dependency settings.
+     */
+    public Boolean omitAllDrivers;
+
+    /**
+     * When true, no connector ZIPs will be packed into the CAR.
+     * All connectors are excluded from the build output.
+     */
+    public Boolean omitAllConnectors;
+
+    /** Key: connector artifactId (e.g. "mi-connector-file"). */
+    public Map<String, ConnectorDependencyConfig> connectors = new HashMap<>();
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -22,17 +22,26 @@ import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
 import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
 import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -46,6 +55,9 @@ import java.util.logging.Logger;
 public class ConnectorConfigService {
 
     private static final Logger LOGGER = Logger.getLogger(ConnectorConfigService.class.getName());
+
+    private static final Path LOCAL_ENTRIES_RELATIVE_PATH =
+            Path.of("src", "main", "wso2mi", "artifacts", "local-entries");
 
     /** Relative path of the config file within the project root. */
     private static final String CONFIG_RELATIVE_PATH =
@@ -114,7 +126,17 @@ public class ConnectorConfigService {
 
         File configFile = configFile(projectPath);
         configFile.getParentFile().mkdirs();
-        JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValue(configFile, config);
+        // Write to a temp file first, then atomically rename so concurrent readers never see
+        // a partially written file. Falls back to a non-atomic replace on filesystems that do
+        // not support ATOMIC_MOVE (e.g. cross-device mounts).
+        Path target = configFile.toPath();
+        Path tmp = target.resolveSibling(configFile.getName() + ".tmp");
+        JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValue(tmp.toFile(), config);
+        try {
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
         LOGGER.log(Level.INFO, "connector-config.json written to: " + configFile.getAbsolutePath());
     }
 
@@ -126,15 +148,17 @@ public class ConnectorConfigService {
      */
     public static void initIfAbsent(String projectPath) {
 
-        File configFile = configFile(projectPath);
-        if (!configFile.exists()) {
-            try {
-                ConnectorConfig initial = new ConnectorConfig();
-                initial.version = CONFIG_VERSION;
-                writeConfig(projectPath, initial);
-                LOGGER.log(Level.INFO, "Created initial connector-config.json at: " + configFile.getAbsolutePath());
-            } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Could not create connector-config.json: " + e.getMessage());
+        synchronized (lockFor(projectPath)) {
+            File configFile = configFile(projectPath);
+            if (!configFile.exists()) {
+                try {
+                    ConnectorConfig initial = new ConnectorConfig();
+                    initial.version = CONFIG_VERSION;
+                    writeConfig(projectPath, initial);
+                    LOGGER.log(Level.INFO, "Created initial connector-config.json at: " + configFile.getAbsolutePath());
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Could not create connector-config.json: " + e.getMessage());
+                }
             }
         }
     }
@@ -169,6 +193,7 @@ public class ConnectorConfigService {
             ConnectorConfig config = readConfig(projectPath);
             ConnectorDependencyConfig connectorCfg = config.connectors.computeIfAbsent(
                     request.connectorArtifactId, k -> new ConnectorDependencyConfig());
+            populateQNameIfAbsent(connectorCfg, request.connectorArtifactId);
             if (connectorCfg.dependencies == null) {
                 connectorCfg.dependencies = new ArrayList<>();
             }
@@ -178,30 +203,35 @@ public class ConnectorConfigService {
                     connectorCfg.dependencies, request.connectionType, request.groupId, request.artifactId);
 
             if (existing != null) {
-                // Update in-place
+                // Update in-place; blank strings are normalized to null so they are
+                // omitted from the serialized JSON and don't break matching/merging.
                 if (request.connectionType != null) {
-                    existing.connectionType = request.connectionType;
+                    existing.connectionType = blankToNull(request.connectionType);
                 }
                 if (request.groupId != null) {
-                    existing.groupId = request.groupId;
+                    existing.groupId = blankToNull(request.groupId);
                 }
                 if (request.artifactId != null) {
-                    existing.artifactId = request.artifactId;
+                    existing.artifactId = blankToNull(request.artifactId);
                 }
                 if (request.version != null) {
-                    existing.version = request.version;
+                    existing.version = blankToNull(request.version);
                 }
                 if (request.omit != null) {
                     existing.omit = request.omit;
                 }
+                if (request.localPath != null) {
+                    existing.localPath = blankToNull(request.localPath);
+                }
             } else {
                 // Add new entry
                 DependencyOverride override = new DependencyOverride();
-                override.connectionType = request.connectionType;
-                override.groupId = request.groupId;
-                override.artifactId = request.artifactId;
-                override.version = request.version;
+                override.connectionType = blankToNull(request.connectionType);
+                override.groupId = blankToNull(request.groupId);
+                override.artifactId = blankToNull(request.artifactId);
+                override.version = blankToNull(request.version);
                 override.omit = request.omit;
+                override.localPath = blankToNull(request.localPath);
                 connectorCfg.dependencies.add(override);
             }
 
@@ -281,9 +311,9 @@ public class ConnectorConfigService {
         response.omitAllConnectors = Boolean.TRUE.equals(config.omitAllConnectors);
         if (connectorArtifactId != null) {
             List<Map<String, Object>> descriptorDeps = readDescriptorDependencies(connectorArtifactId);
-            response.dependencies = mergeDependencies(descriptorDeps, config, connectorArtifactId);
+            response.dependencies = mergeDependencies(descriptorDeps, config, connectorArtifactId, projectPath);
         } else {
-            response.allConnectors = getAllEffectiveDependencies(config);
+            response.allConnectors = getAllEffectiveDependencies(config, projectPath);
         }
         return response;
     }
@@ -292,14 +322,16 @@ public class ConnectorConfigService {
      * Returns the effective dependency lists for every connector currently loaded in the
      * {@link ConnectorHolder}, using the supplied pre-read config.
      *
-     * @param config pre-read connector config
+     * @param config      pre-read connector config
+     * @param projectPath absolute path to the project root (used to scan active connectionTypes)
      * @return map of connectorArtifactId → effective data
      */
-    private static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(ConnectorConfig config) {
+    private static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(ConnectorConfig config,
+                                                                                   String projectPath) {
 
         Map<String, ConnectorEffectiveData> result = new HashMap<>();
         ConnectorHolder holder = ConnectorHolder.getInstance();
-        for (Connector connector : holder.getConnectors()) {
+        for (Connector connector : new ArrayList<>(holder.getConnectors())) {
             String artifactId = connectorArtifactId(connector);
             List<Map<String, Object>> descriptorDeps = readDescriptorDependenciesFromPath(
                     connector.getExtractedConnectorPath());
@@ -311,7 +343,7 @@ public class ConnectorConfigService {
                     || Boolean.TRUE.equals(connectorCfg != null ? connectorCfg.omitAllDrivers : null);
             data.dependencies = descriptorDeps.isEmpty()
                     ? new ArrayList<>()
-                    : mergeDependencies(descriptorDeps, config, artifactId);
+                    : mergeDependencies(descriptorDeps, config, artifactId, projectPath);
             result.put(artifactId, data);
         }
         return result;
@@ -326,21 +358,18 @@ public class ConnectorConfigService {
      */
     public static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(String projectPath) {
 
-        return getAllEffectiveDependencies(readConfig(projectPath));
+        return getAllEffectiveDependencies(readConfig(projectPath), projectPath);
     }
 
     /**
      * Returns {@code true} if driver downloads should be skipped for the given connector, based on
      * the root-level or connector-level {@code omitAllDrivers} flag in {@code connector-config.json}.
      *
-     * <p>The connector is matched by short name: a config entry whose key equals {@code connectorName}
-     * or ends with {@code "-" + connectorName} is considered a match.
-     *
-     * @param projectPath   absolute path to the project root
-     * @param connectorName short connector name as used in {@link ConnectorHolder} (e.g. "file")
+     * @param projectPath         absolute path to the project root
+     * @param connectorArtifactId Maven artifact ID of the connector (e.g. "mi-connector-file")
      * @return {@code true} if all drivers for this connector should be omitted
      */
-    public static boolean isOmitAllDrivers(String projectPath, String connectorName) {
+    public static boolean isOmitAllDrivers(String projectPath, String connectorArtifactId) {
 
         ConnectorConfig config = readConfig(projectPath);
         if (Boolean.TRUE.equals(config.omitAllDrivers)) {
@@ -349,53 +378,31 @@ public class ConnectorConfigService {
         if (config.connectors == null) {
             return false;
         }
-        for (Map.Entry<String, ConnectorDependencyConfig> entry : config.connectors.entrySet()) {
-            String key = entry.getKey();
-            if (key.equals(connectorName) || key.endsWith("-" + connectorName)) {
-                ConnectorDependencyConfig cfg = entry.getValue();
-                return cfg != null && Boolean.TRUE.equals(cfg.omitAllDrivers);
-            }
-        }
-        return false;
+        ConnectorDependencyConfig cfg = findConnectorConfig(config, connectorArtifactId);
+        return cfg != null && Boolean.TRUE.equals(cfg.omitAllDrivers);
     }
 
     /**
-     * Looks up a dependency override using the connector's short name (as held in {@link ConnectorHolder})
-     * and a connection type. This is used by {@code ConnectorDownloadManager} which receives the short
-     * connector name (e.g. "file") rather than the Maven artifactId (e.g. "mi-connector-file").
+     * Looks up a dependency override by connector Maven artifact ID and connection type.
      *
-     * <p>The lookup iterates over all connector entries in connector-config.json and returns the first
-     * override whose entry key ends with the given connectorName and whose connectionType matches.
-     *
-     * @param projectPath    absolute path to the project root
-     * @param connectorName  short connector name (e.g. "file", "amazonsqs")
-     * @param connectionType connection type from descriptor.yml (e.g. "MYSQL")
+     * @param projectPath         absolute path to the project root
+     * @param connectorArtifactId Maven artifact ID of the connector (e.g. "mi-connector-file")
+     * @param connectionType      connection type from descriptor.yml (e.g. "MYSQL")
      * @return the matching override, or {@code null} if none found
      */
     public static DependencyOverride findOverrideByConnectorNameAndConnectionType(String projectPath,
-                                                                                  String connectorName,
+                                                                                  String connectorArtifactId,
                                                                                   String connectionType) {
 
         ConnectorConfig config = readConfig(projectPath);
         if (config.connectors == null || config.connectors.isEmpty()) {
             return null;
         }
-        for (Map.Entry<String, ConnectorDependencyConfig> entry : config.connectors.entrySet()) {
-            // Match by suffix: "mi-connector-file" ends with "-file"
-            String key = entry.getKey();
-            if (!key.equals(connectorName) && !key.endsWith("-" + connectorName)) {
-                continue;
-            }
-            ConnectorDependencyConfig cfg = entry.getValue();
-            if (cfg == null || cfg.dependencies == null) {
-                continue;
-            }
-            DependencyOverride match = findMatchingOverride(cfg.dependencies, connectionType, null, null);
-            if (match != null) {
-                return match;
-            }
+        ConnectorDependencyConfig cfg = findConnectorConfig(config, connectorArtifactId);
+        if (cfg == null || cfg.dependencies == null) {
+            return null;
         }
-        return null;
+        return findMatchingOverride(cfg.dependencies, connectionType, null, null);
     }
 
     // -------------------------------------------------------------------------
@@ -413,8 +420,9 @@ public class ConnectorConfigService {
      */
     private static List<Map<String, Object>> readDescriptorDependencies(String connectorArtifactId) {
 
-        Connector connector = ConnectorHolder.getInstance().getConnectors().stream()
-                .filter(c -> connectorArtifactId.equals(connectorArtifactId(c)))
+        Connector connector = new ArrayList<>(ConnectorHolder.getInstance().getConnectors()).stream()
+                .filter(c -> connectorArtifactId.equals(connectorArtifactId(c))
+                        || connectorArtifactId.equals(c.getName()))
                 .findFirst().orElse(null);
         if (connector == null) {
             return Collections.emptyList();
@@ -447,18 +455,23 @@ public class ConnectorConfigService {
 
     /**
      * Merges descriptor.yml dependency entries with connector-config.json overrides.
+     * Also sets {@link EffectiveDependency#isConnectionTypeActive} by scanning the project's
+     * local entries to find which connectionTypes are in use.
      */
     private static List<EffectiveDependency> mergeDependencies(List<Map<String, Object>> descriptorDeps,
                                                                ConnectorConfig config,
-                                                               String connectorArtifactId) {
+                                                               String connectorArtifactId,
+                                                               String projectPath) {
 
-        ConnectorDependencyConfig connectorCfg = config.connectors.get(connectorArtifactId);
+        ConnectorDependencyConfig connectorCfg = findConnectorConfig(config, connectorArtifactId);
         boolean globalOmitAllDrivers = Boolean.TRUE.equals(config.omitAllDrivers)
                 || (connectorCfg != null && Boolean.TRUE.equals(connectorCfg.omitAllDrivers));
         List<DependencyOverride> overrides =
                 (connectorCfg != null && connectorCfg.dependencies != null)
                         ? connectorCfg.dependencies
                         : Collections.emptyList();
+
+        Set<String> activeConnectionTypes = scanActiveConnectionTypes(projectPath);
 
         List<EffectiveDependency> result = new ArrayList<>();
         for (Map<String, Object> dep : descriptorDeps) {
@@ -474,6 +487,9 @@ public class ConnectorConfigService {
             eff.defaultVersion = version;
             eff.groupId = groupId;
             eff.artifactId = artifactId;
+            // Deps without a connectionType are always "active"; those with one are active only
+            // when a local entry uses that connectionType.
+            eff.isConnectionTypeActive = (connectionType == null) || activeConnectionTypes.contains(connectionType);
 
             if (globalOmitAllDrivers) {
                 eff.omit = true;
@@ -490,10 +506,71 @@ public class ConnectorConfigService {
                 if (!StringUtils.isBlank(override.version)) {
                     eff.overriddenVersion = override.version;
                 }
+                if (!StringUtils.isBlank(override.localPath)) {
+                    eff.localPath = override.localPath;
+                }
             }
             result.add(eff);
         }
         return result;
+    }
+
+    /**
+     * Scans the project's local-entries folder and returns the set of connectionType values
+     * that are currently active (each *.init element that has a connectionType child).
+     */
+    private static Set<String> scanActiveConnectionTypes(String projectPath) {
+
+        Set<String> active = new HashSet<>();
+        if (StringUtils.isBlank(projectPath)) {
+            return active;
+        }
+        File localEntriesDir = Path.of(projectPath).resolve(LOCAL_ENTRIES_RELATIVE_PATH).toFile();
+        if (!localEntriesDir.isDirectory()) {
+            return active;
+        }
+        File[] files = localEntriesDir.listFiles(f -> f.isFile() && f.getName().endsWith(".xml"));
+        if (files == null) {
+            return active;
+        }
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            // Harden against XXE attacks
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setExpandEntityReferences(false);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            for (File file : files) {
+                try {
+                    Document doc = builder.parse(file);
+                    Element root = doc.getDocumentElement();
+                    NodeList allNodes = root.getElementsByTagName("*");
+                    for (int i = 0; i < allNodes.getLength(); i++) {
+                        Element el = (Element) allNodes.item(i);
+                        if (el.getNodeName().endsWith(".init")) {
+                            NodeList ctNodes = el.getElementsByTagName("connectionType");
+                            if (ctNodes.getLength() > 0) {
+                                String ct = ctNodes.item(0).getTextContent().trim();
+                                if (!ct.isEmpty()) {
+                                    active.add(ct);
+                                }
+                            }
+                            break;
+                        }
+                    }
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Failed to parse local entry file " + file.getName()
+                            + ": " + e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to initialize XML parser for local entries: " + e.getMessage());
+        }
+        return active;
     }
 
     /** Finds the best-matching override by connectionType, then by groupId+artifactId. */
@@ -533,10 +610,15 @@ public class ConnectorConfigService {
     public static void updateConnectorFlags(String projectPath, UpdateConnectorFlagsRequest request)
             throws IOException {
 
+        if (StringUtils.isBlank(request.connectorArtifactId)) {
+            throw new IllegalArgumentException("connectorArtifactId must not be blank");
+        }
+
         synchronized (lockFor(projectPath)) {
             ConnectorConfig config = readConfig(projectPath);
             ConnectorDependencyConfig connectorCfg = config.connectors.computeIfAbsent(
                     request.connectorArtifactId, k -> new ConnectorDependencyConfig());
+            populateQNameIfAbsent(connectorCfg, request.connectorArtifactId);
 
             if (request.omit != null) {
                 connectorCfg.omit = request.omit ? Boolean.TRUE : null;
@@ -562,7 +644,7 @@ public class ConnectorConfigService {
      * @param request     the root config update request
      * @throws IOException if the config file cannot be read or written
      */
-    public static void updateRootConfig(String projectPath, UpdateRootConfigRequest request)
+    public static void updateGlobalConnectorFlags(String projectPath, UpdateGlobalConnectorFlagsRequest request)
             throws IOException {
 
         synchronized (lockFor(projectPath)) {
@@ -580,7 +662,52 @@ public class ConnectorConfigService {
     }
 
     /**
-     * Derives the Maven artifactId from a loaded Connector.
+     * Looks up a connector's dependency config by its canonical Maven artifact ID.
+     *
+     * <p>As a backward-compatibility measure, if no exact match is found the method merges all
+     * entries whose key matches by suffix (e.g. both "db" and "mi-connector-db"), so that existing
+     * config files written before the canonical-key convention are still honoured.
+     */
+    private static ConnectorDependencyConfig findConnectorConfig(ConnectorConfig config, String canonicalArtifactId) {
+
+        if (config.connectors == null) {
+            return null;
+        }
+        // Fast path: canonical key present
+        ConnectorDependencyConfig exact = config.connectors.get(canonicalArtifactId);
+        if (exact != null) {
+            return exact;
+        }
+        // Backward-compat: collect all entries that refer to the same connector under old key forms
+        List<ConnectorDependencyConfig> matches = new ArrayList<>();
+        for (Map.Entry<String, ConnectorDependencyConfig> entry : config.connectors.entrySet()) {
+            String key = entry.getKey();
+            if (key.endsWith("-" + canonicalArtifactId) || canonicalArtifactId.endsWith("-" + key)) {
+                matches.add(entry.getValue());
+            }
+        }
+        if (matches.isEmpty()) {
+            return null;
+        }
+        if (matches.size() == 1) {
+            return matches.get(0);
+        }
+        ConnectorDependencyConfig merged = new ConnectorDependencyConfig();
+        merged.dependencies = new ArrayList<>();
+        for (ConnectorDependencyConfig cfg : matches) {
+            if (cfg.omit != null) merged.omit = cfg.omit;
+            if (cfg.omitAllDrivers != null) merged.omitAllDrivers = cfg.omitAllDrivers;
+            if (cfg.dependencies != null) merged.dependencies.addAll(cfg.dependencies);
+        }
+        return merged;
+    }
+
+    /** Returns {@code null} when the value is null or blank; otherwise returns the value as-is. */
+    private static String blankToNull(String value) {
+        return StringUtils.isBlank(value) ? null : value;
+    }
+
+    /**
      * Uses the artifactId already parsed by ConnectorReader from the extracted folder name,
      * falling back to the connector's short name if not set.
      */
@@ -592,4 +719,34 @@ public class ConnectorConfigService {
         }
         return connector.getName();
     }
+
+    /**
+     * Populates the {@code qname} field on a connector config entry if it is not already set.
+     * The QName is derived from the connector's package and name as read by ConnectorReader, and
+     * takes the form {@code {packageName}name} — the same string that the CAR plugin uses as the
+     * lib subdirectory name.
+     *
+     * @param connectorCfg        the config entry to update
+     * @param connectorArtifactId the Maven artifact ID used to locate the connector in the holder
+     */
+    private static void populateQNameIfAbsent(ConnectorDependencyConfig connectorCfg,
+                                              String connectorArtifactId) {
+
+        if (connectorCfg.qname != null) {
+            return; // already set
+        }
+        Connector connector = new ArrayList<>(ConnectorHolder.getInstance().getConnectors()).stream()
+                .filter(c -> connectorArtifactId.equals(connectorArtifactId(c))
+                        || connectorArtifactId.equals(c.getName()))
+                .findFirst().orElse(null);
+        if (connector == null) {
+            return;
+        }
+        String pkg = connector.getPackageName();
+        String name = connector.getName();
+        if (!StringUtils.isBlank(pkg) && !StringUtils.isBlank(name)) {
+            connectorCfg.qname = "{" + pkg + "}" + name;
+        }
+    }
+
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
@@ -33,10 +33,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
 
 /**
  * Manages reading and writing {@code connector-config.json} and provides the merged
@@ -49,19 +49,24 @@ public class ConnectorConfigService {
 
     /** Relative path of the config file within the project root. */
     private static final String CONFIG_RELATIVE_PATH =
-            "src" + File.separator + "main" + File.separator + "wso2mi" + File.separator + "connector-config.json";
+            "src" + File.separator + "main" + File.separator + "wso2mi" + File.separator
+            + "resources" + File.separator + "connectors" + File.separator + "connector-config.json";
 
     private static final String CONFIG_VERSION = "1.0";
-
-    /** Matches a versioned connector artifact name, e.g. "mi-connector-file-4.0.36". */
-    private static final Pattern ARTIFACT_ID_PATTERN = Pattern.compile("^(.+)-(\\d+(?:\\.\\d+)+)$");
 
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
     private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 
+    /** Per-project lock objects to prevent concurrent read-modify-write races on the config file. */
+    private static final ConcurrentHashMap<String, Object> CONFIG_LOCKS = new ConcurrentHashMap<>();
+
     private ConnectorConfigService() {
+    }
+
+    private static Object lockFor(String projectPath) {
+        return CONFIG_LOCKS.computeIfAbsent(projectPath, k -> new Object());
     }
 
     // -------------------------------------------------------------------------
@@ -73,6 +78,9 @@ public class ConnectorConfigService {
      *
      * @param projectPath absolute path to the project root
      * @return parsed config, or an empty config if the file does not exist
+     * @throws IllegalStateException if the file exists but cannot be parsed — callers must not
+     *         proceed with a write in this case, as doing so would silently overwrite the file
+     *         with an empty config
      */
     public static ConnectorConfig readConfig(String projectPath) {
 
@@ -89,10 +97,9 @@ public class ConnectorConfigService {
             }
             return config;
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to read connector-config.json: " + e.getMessage());
-            ConnectorConfig empty = new ConnectorConfig();
-            empty.version = CONFIG_VERSION;
-            return empty;
+            LOGGER.log(Level.SEVERE, "connector-config.json is malformed and cannot be read: " + e.getMessage());
+            throw new IllegalStateException(
+                    "connector-config.json is malformed: " + e.getMessage(), e);
         }
     }
 
@@ -148,46 +155,58 @@ public class ConnectorConfigService {
     public static void updateDependencyOverride(String projectPath, UpdateConnectorDependencyRequest request)
             throws IOException {
 
-        ConnectorConfig config = readConfig(projectPath);
-        ConnectorDependencyConfig connectorCfg = config.connectors.computeIfAbsent(
-                request.connectorArtifactId, k -> new ConnectorDependencyConfig());
-        if (connectorCfg.dependencies == null) {
-            connectorCfg.dependencies = new ArrayList<>();
+        if (StringUtils.isBlank(request.connectorArtifactId)) {
+            throw new IllegalArgumentException("connectorArtifactId must not be blank");
+        }
+        boolean hasConnectionType = !StringUtils.isBlank(request.connectionType);
+        boolean hasCoordinates = !StringUtils.isBlank(request.groupId) && !StringUtils.isBlank(request.artifactId);
+        if (!hasConnectionType && !hasCoordinates) {
+            throw new IllegalArgumentException(
+                    "At least one of connectionType or (groupId + artifactId) must be provided");
         }
 
-        // Find existing entry to replace
-        DependencyOverride existing = findMatchingOverride(
-                connectorCfg.dependencies, request.connectionType, request.groupId, request.artifactId);
+        synchronized (lockFor(projectPath)) {
+            ConnectorConfig config = readConfig(projectPath);
+            ConnectorDependencyConfig connectorCfg = config.connectors.computeIfAbsent(
+                    request.connectorArtifactId, k -> new ConnectorDependencyConfig());
+            if (connectorCfg.dependencies == null) {
+                connectorCfg.dependencies = new ArrayList<>();
+            }
 
-        if (existing != null) {
-            // Update in-place
-            if (request.connectionType != null) {
-                existing.connectionType = request.connectionType;
+            // Find existing entry to replace
+            DependencyOverride existing = findMatchingOverride(
+                    connectorCfg.dependencies, request.connectionType, request.groupId, request.artifactId);
+
+            if (existing != null) {
+                // Update in-place
+                if (request.connectionType != null) {
+                    existing.connectionType = request.connectionType;
+                }
+                if (request.groupId != null) {
+                    existing.groupId = request.groupId;
+                }
+                if (request.artifactId != null) {
+                    existing.artifactId = request.artifactId;
+                }
+                if (request.version != null) {
+                    existing.version = request.version;
+                }
+                if (request.omit != null) {
+                    existing.omit = request.omit;
+                }
+            } else {
+                // Add new entry
+                DependencyOverride override = new DependencyOverride();
+                override.connectionType = request.connectionType;
+                override.groupId = request.groupId;
+                override.artifactId = request.artifactId;
+                override.version = request.version;
+                override.omit = request.omit;
+                connectorCfg.dependencies.add(override);
             }
-            if (request.groupId != null) {
-                existing.groupId = request.groupId;
-            }
-            if (request.artifactId != null) {
-                existing.artifactId = request.artifactId;
-            }
-            if (request.version != null) {
-                existing.version = request.version;
-            }
-            if (request.omit != null) {
-                existing.omit = request.omit;
-            }
-        } else {
-            // Add new entry
-            DependencyOverride override = new DependencyOverride();
-            override.connectionType = request.connectionType;
-            override.groupId = request.groupId;
-            override.artifactId = request.artifactId;
-            override.version = request.version;
-            override.omit = request.omit;
-            connectorCfg.dependencies.add(override);
+
+            writeConfig(projectPath, config);
         }
-
-        writeConfig(projectPath, config);
     }
 
     /**
@@ -202,31 +221,42 @@ public class ConnectorConfigService {
     public static void resetDependencyOverrides(String projectPath, ResetConnectorDependencyRequest request)
             throws IOException {
 
-        ConnectorConfig config = readConfig(projectPath);
-        ConnectorDependencyConfig connectorCfg = config.connectors.get(request.connectorArtifactId);
-        if (connectorCfg == null || connectorCfg.dependencies == null) {
-            return; // nothing to reset
+        // Partial groupId/artifactId (only one provided) is ambiguous — treat as no-op
+        boolean hasGroupId = !StringUtils.isBlank(request.groupId);
+        boolean hasArtifactId = !StringUtils.isBlank(request.artifactId);
+        if (hasGroupId != hasArtifactId) {
+            LOGGER.log(Level.WARNING, "resetDependencyOverrides: groupId and artifactId must both be "
+                    + "provided or both omitted; ignoring request.");
+            return;
         }
 
-        if (request.connectionType != null) {
-            // Remove only the entry matching this connectionType
-            connectorCfg.dependencies.removeIf(
-                    o -> request.connectionType.equalsIgnoreCase(o.connectionType));
-        } else if (request.groupId != null && request.artifactId != null) {
-            // Remove the entry matching groupId+artifactId (for deps without connectionType)
-            connectorCfg.dependencies.removeIf(
-                    o -> o.connectionType == null
-                            && request.groupId.equals(o.groupId)
-                            && request.artifactId.equals(o.artifactId));
-        } else {
-            // Remove all overrides for this connector
-            config.connectors.remove(request.connectorArtifactId);
+        synchronized (lockFor(projectPath)) {
+            ConnectorConfig config = readConfig(projectPath);
+            ConnectorDependencyConfig connectorCfg = config.connectors.get(request.connectorArtifactId);
+            if (connectorCfg == null || connectorCfg.dependencies == null) {
+                return; // nothing to reset
+            }
+
+            if (request.connectionType != null) {
+                // Remove only the entry matching this connectionType
+                connectorCfg.dependencies.removeIf(
+                        o -> request.connectionType.equalsIgnoreCase(o.connectionType));
+            } else if (hasGroupId) {
+                // Remove the entry matching groupId+artifactId (for deps without connectionType)
+                connectorCfg.dependencies.removeIf(
+                        o -> o.connectionType == null
+                                && request.groupId.equals(o.groupId)
+                                && request.artifactId.equals(o.artifactId));
+            } else {
+                // Remove all overrides for this connector
+                config.connectors.remove(request.connectorArtifactId);
+            }
+            if (connectorCfg.dependencies != null && connectorCfg.dependencies.isEmpty()
+                    && connectorCfg.omit == null && connectorCfg.omitAllDrivers == null) {
+                config.connectors.remove(request.connectorArtifactId);
+            }
+            writeConfig(projectPath, config);
         }
-        if (connectorCfg.dependencies != null && connectorCfg.dependencies.isEmpty()
-                && connectorCfg.omit == null && connectorCfg.omitAllDrivers == null) {
-            config.connectors.remove(request.connectorArtifactId);
-        }
-        writeConfig(projectPath, config);
     }
 
     // -------------------------------------------------------------------------
@@ -234,33 +264,40 @@ public class ConnectorConfigService {
     // -------------------------------------------------------------------------
 
     /**
-     * Returns the effective dependency list for a single connector — descriptor.yml defaults
-     * merged with any overrides in connector-config.json.
+     * Reads the config once and builds the full {@link ConnectorDependencyResponse}, populating root-level
+     * flags plus either per-connector or all-connector effective dependencies.
+     * Avoids redundant disk reads compared to reading the config separately for flags and dependencies.
      *
      * @param projectPath         absolute path to the project root
-     * @param connectorArtifactId connector Maven artifactId (e.g. "mi-connector-file")
-     * @return list of effective dependencies; empty if the connector has no descriptor.yml
+     * @param connectorArtifactId if non-null, populate single-connector dependencies; otherwise all connectors
+     * @return the populated response
      */
-    public static List<EffectiveDependency> getEffectiveDependencies(String projectPath,
-                                                                     String connectorArtifactId) {
+    public static ConnectorDependencyResponse buildDependencyResponse(String projectPath,
+                                                                      String connectorArtifactId) {
 
         ConnectorConfig config = readConfig(projectPath);
-        List<Map<String, Object>> descriptorDeps = readDescriptorDependencies(connectorArtifactId);
-        return mergeDependencies(descriptorDeps, config, connectorArtifactId);
+        ConnectorDependencyResponse response = new ConnectorDependencyResponse();
+        response.omitAllDrivers = Boolean.TRUE.equals(config.omitAllDrivers);
+        response.omitAllConnectors = Boolean.TRUE.equals(config.omitAllConnectors);
+        if (connectorArtifactId != null) {
+            List<Map<String, Object>> descriptorDeps = readDescriptorDependencies(connectorArtifactId);
+            response.dependencies = mergeDependencies(descriptorDeps, config, connectorArtifactId);
+        } else {
+            response.allConnectors = getAllEffectiveDependencies(config);
+        }
+        return response;
     }
 
     /**
      * Returns the effective dependency lists for every connector currently loaded in the
-     * {@link ConnectorHolder}.
+     * {@link ConnectorHolder}, using the supplied pre-read config.
      *
-     * @param projectPath absolute path to the project root
-     * @return map of connectorArtifactId → list of effective dependencies
+     * @param config pre-read connector config
+     * @return map of connectorArtifactId → effective data
      */
-    public static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(String projectPath) {
+    private static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(ConnectorConfig config) {
 
-        ConnectorConfig config = readConfig(projectPath);
         Map<String, ConnectorEffectiveData> result = new HashMap<>();
-
         ConnectorHolder holder = ConnectorHolder.getInstance();
         for (Connector connector : holder.getConnectors()) {
             String artifactId = connectorArtifactId(connector);
@@ -272,14 +309,54 @@ public class ConnectorConfigService {
             data.omit = Boolean.TRUE.equals(connectorCfg != null ? connectorCfg.omit : null);
             data.omitAllDrivers = Boolean.TRUE.equals(config.omitAllDrivers)
                     || Boolean.TRUE.equals(connectorCfg != null ? connectorCfg.omitAllDrivers : null);
-            if (descriptorDeps != null && !descriptorDeps.isEmpty()) {
-                data.dependencies = mergeDependencies(descriptorDeps, config, artifactId);
-            } else {
-                data.dependencies = new ArrayList<>();
-            }
+            data.dependencies = descriptorDeps.isEmpty()
+                    ? new ArrayList<>()
+                    : mergeDependencies(descriptorDeps, config, artifactId);
             result.put(artifactId, data);
         }
         return result;
+    }
+
+    /**
+     * Returns the effective dependency lists for every connector currently loaded in the
+     * {@link ConnectorHolder}.
+     *
+     * @param projectPath absolute path to the project root
+     * @return map of connectorArtifactId → list of effective dependencies
+     */
+    public static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(String projectPath) {
+
+        return getAllEffectiveDependencies(readConfig(projectPath));
+    }
+
+    /**
+     * Returns {@code true} if driver downloads should be skipped for the given connector, based on
+     * the root-level or connector-level {@code omitAllDrivers} flag in {@code connector-config.json}.
+     *
+     * <p>The connector is matched by short name: a config entry whose key equals {@code connectorName}
+     * or ends with {@code "-" + connectorName} is considered a match.
+     *
+     * @param projectPath   absolute path to the project root
+     * @param connectorName short connector name as used in {@link ConnectorHolder} (e.g. "file")
+     * @return {@code true} if all drivers for this connector should be omitted
+     */
+    public static boolean isOmitAllDrivers(String projectPath, String connectorName) {
+
+        ConnectorConfig config = readConfig(projectPath);
+        if (Boolean.TRUE.equals(config.omitAllDrivers)) {
+            return true;
+        }
+        if (config.connectors == null) {
+            return false;
+        }
+        for (Map.Entry<String, ConnectorDependencyConfig> entry : config.connectors.entrySet()) {
+            String key = entry.getKey();
+            if (key.equals(connectorName) || key.endsWith("-" + connectorName)) {
+                ConnectorDependencyConfig cfg = entry.getValue();
+                return cfg != null && Boolean.TRUE.equals(cfg.omitAllDrivers);
+            }
+        }
+        return false;
     }
 
     /**
@@ -456,24 +533,26 @@ public class ConnectorConfigService {
     public static void updateConnectorFlags(String projectPath, UpdateConnectorFlagsRequest request)
             throws IOException {
 
-        ConnectorConfig config = readConfig(projectPath);
-        ConnectorDependencyConfig connectorCfg = config.connectors.computeIfAbsent(
-                request.connectorArtifactId, k -> new ConnectorDependencyConfig());
+        synchronized (lockFor(projectPath)) {
+            ConnectorConfig config = readConfig(projectPath);
+            ConnectorDependencyConfig connectorCfg = config.connectors.computeIfAbsent(
+                    request.connectorArtifactId, k -> new ConnectorDependencyConfig());
 
-        if (request.omit != null) {
-            connectorCfg.omit = request.omit ? Boolean.TRUE : null;
-        }
-        if (request.omitAllDrivers != null) {
-            connectorCfg.omitAllDrivers = request.omitAllDrivers ? Boolean.TRUE : null;
-        }
+            if (request.omit != null) {
+                connectorCfg.omit = request.omit ? Boolean.TRUE : null;
+            }
+            if (request.omitAllDrivers != null) {
+                connectorCfg.omitAllDrivers = request.omitAllDrivers ? Boolean.TRUE : null;
+            }
 
-        // If all fields on the connector config are now null/empty, remove the entry
-        if (connectorCfg.omit == null && connectorCfg.omitAllDrivers == null
-                && (connectorCfg.dependencies == null || connectorCfg.dependencies.isEmpty())) {
-            config.connectors.remove(request.connectorArtifactId);
-        }
+            // If all fields on the connector config are now null/empty, remove the entry
+            if (connectorCfg.omit == null && connectorCfg.omitAllDrivers == null
+                    && (connectorCfg.dependencies == null || connectorCfg.dependencies.isEmpty())) {
+                config.connectors.remove(request.connectorArtifactId);
+            }
 
-        writeConfig(projectPath, config);
+            writeConfig(projectPath, config);
+        }
     }
 
     /**
@@ -486,40 +565,31 @@ public class ConnectorConfigService {
     public static void updateRootConfig(String projectPath, UpdateRootConfigRequest request)
             throws IOException {
 
-        ConnectorConfig config = readConfig(projectPath);
+        synchronized (lockFor(projectPath)) {
+            ConnectorConfig config = readConfig(projectPath);
 
-        if (request.omitAllDrivers != null) {
-            config.omitAllDrivers = request.omitAllDrivers ? Boolean.TRUE : null;
-        }
-        if (request.omitAllConnectors != null) {
-            config.omitAllConnectors = request.omitAllConnectors ? Boolean.TRUE : null;
-        }
+            if (request.omitAllDrivers != null) {
+                config.omitAllDrivers = request.omitAllDrivers ? Boolean.TRUE : null;
+            }
+            if (request.omitAllConnectors != null) {
+                config.omitAllConnectors = request.omitAllConnectors ? Boolean.TRUE : null;
+            }
 
-        writeConfig(projectPath, config);
+            writeConfig(projectPath, config);
+        }
     }
 
     /**
-     * Derives the Maven artifactId from a loaded Connector by inspecting its ZIP file name.
-     * Falls back to the connector's short name if no version suffix is found.
+     * Derives the Maven artifactId from a loaded Connector.
+     * Uses the artifactId already parsed by ConnectorReader from the extracted folder name,
+     * falling back to the connector's short name if not set.
      */
     private static String connectorArtifactId(Connector connector) {
 
-        List<File> zips = ConnectorHolder.getInstance().getConnectorZips();
-        if (zips != null) {
-            for (File zip : zips) {
-                String name = zip.getName().replace(".zip", "");
-                Matcher m = ARTIFACT_ID_PATTERN.matcher(name);
-                if (m.matches()) {
-                    // Check if this ZIP corresponds to this connector by short name
-                    String candidateArtifactId = m.group(1);
-                    if (candidateArtifactId.endsWith("-" + connector.getName())
-                            || candidateArtifactId.equals(connector.getName())) {
-                        return candidateArtifactId;
-                    }
-                }
-            }
+        String artifactId = connector.getArtifactId();
+        if (artifactId != null && !artifactId.isBlank()) {
+            return artifactId;
         }
-        // Fallback
         return connector.getName();
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
@@ -375,7 +375,7 @@ public class ConnectorConfigService {
      * @param projectPath absolute path to the project root
      * @return map of connectorArtifactId → list of effective dependencies
      */
-    public static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(String projectPath) {
+    private static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(String projectPath) {
 
         return getAllEffectiveDependencies(readConfig(projectPath), projectPath);
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.lemminx.customservice.synapse.connectors.ConnectorHolder;
+import org.eclipse.lemminx.customservice.synapse.connectors.entity.Connector;
+import org.eclipse.lemminx.customservice.synapse.utils.Constant;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Manages reading and writing {@code connector-config.json} and provides the merged
+ * (effective) view of connector dependencies by combining descriptor.yml defaults with
+ * user overrides.
+ */
+public class ConnectorConfigService {
+
+    private static final Logger LOGGER = Logger.getLogger(ConnectorConfigService.class.getName());
+
+    /** Relative path of the config file within the project root. */
+    private static final String CONFIG_RELATIVE_PATH =
+            "src" + File.separator + "main" + File.separator + "wso2mi" + File.separator + "connector-config.json";
+
+    private static final String CONFIG_VERSION = "1.0";
+
+    /** Matches a versioned connector artifact name, e.g. "mi-connector-file-4.0.36". */
+    private static final Pattern ARTIFACT_ID_PATTERN = Pattern.compile("^(.+)-(\\d+(?:\\.\\d+)+)$");
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    private ConnectorConfigService() {
+    }
+
+    // -------------------------------------------------------------------------
+    // Read / Write
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reads {@code connector-config.json} from the project.
+     *
+     * @param projectPath absolute path to the project root
+     * @return parsed config, or an empty config if the file does not exist
+     */
+    public static ConnectorConfig readConfig(String projectPath) {
+
+        File configFile = configFile(projectPath);
+        if (!configFile.exists()) {
+            ConnectorConfig empty = new ConnectorConfig();
+            empty.version = CONFIG_VERSION;
+            return empty;
+        }
+        try {
+            ConnectorConfig config = JSON_MAPPER.readValue(configFile, ConnectorConfig.class);
+            if (config.connectors == null) {
+                config.connectors = new HashMap<>();
+            }
+            return config;
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to read connector-config.json: " + e.getMessage());
+            ConnectorConfig empty = new ConnectorConfig();
+            empty.version = CONFIG_VERSION;
+            return empty;
+        }
+    }
+
+    /**
+     * Writes the given config back to {@code connector-config.json}.
+     *
+     * @param projectPath absolute path to the project root
+     * @param config      the config to persist
+     * @throws IOException if the write fails
+     */
+    public static void writeConfig(String projectPath, ConnectorConfig config) throws IOException {
+
+        File configFile = configFile(projectPath);
+        configFile.getParentFile().mkdirs();
+        JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValue(configFile, config);
+        LOGGER.log(Level.INFO, "connector-config.json written to: " + configFile.getAbsolutePath());
+    }
+
+    /**
+     * Creates an empty {@code connector-config.json} in the project if one does not already exist.
+     * Called when the first connector is added to a project.
+     *
+     * @param projectPath absolute path to the project root
+     */
+    public static void initIfAbsent(String projectPath) {
+
+        File configFile = configFile(projectPath);
+        if (!configFile.exists()) {
+            try {
+                ConnectorConfig initial = new ConnectorConfig();
+                initial.version = CONFIG_VERSION;
+                writeConfig(projectPath, initial);
+                LOGGER.log(Level.INFO, "Created initial connector-config.json at: " + configFile.getAbsolutePath());
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Could not create connector-config.json: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Override management
+    // -------------------------------------------------------------------------
+
+    /**
+     * Adds or updates a dependency override for a specific connector.
+     * If an override already exists for the same connectionType (or groupId+artifactId),
+     * it is replaced. Otherwise a new entry is appended.
+     *
+     * @param projectPath absolute path to the project root
+     * @param request     the override to apply
+     * @throws IOException if the config file cannot be read or written
+     */
+    public static void updateDependencyOverride(String projectPath, UpdateConnectorDependencyRequest request)
+            throws IOException {
+
+        ConnectorConfig config = readConfig(projectPath);
+        ConnectorDependencyConfig connectorCfg = config.connectors.computeIfAbsent(
+                request.connectorArtifactId, k -> new ConnectorDependencyConfig());
+        if (connectorCfg.dependencies == null) {
+            connectorCfg.dependencies = new ArrayList<>();
+        }
+
+        // Find existing entry to replace
+        DependencyOverride existing = findMatchingOverride(
+                connectorCfg.dependencies, request.connectionType, request.groupId, request.artifactId);
+
+        if (existing != null) {
+            // Update in-place
+            if (request.connectionType != null) {
+                existing.connectionType = request.connectionType;
+            }
+            if (request.groupId != null) {
+                existing.groupId = request.groupId;
+            }
+            if (request.artifactId != null) {
+                existing.artifactId = request.artifactId;
+            }
+            if (request.version != null) {
+                existing.version = request.version;
+            }
+            if (request.omit != null) {
+                existing.omit = request.omit;
+            }
+        } else {
+            // Add new entry
+            DependencyOverride override = new DependencyOverride();
+            override.connectionType = request.connectionType;
+            override.groupId = request.groupId;
+            override.artifactId = request.artifactId;
+            override.version = request.version;
+            override.omit = request.omit;
+            connectorCfg.dependencies.add(override);
+        }
+
+        writeConfig(projectPath, config);
+    }
+
+    /**
+     * Removes dependency overrides for a connector.
+     * If {@code request.connectionType} is non-null, only the matching entry is removed.
+     * Otherwise all overrides for the connector are removed.
+     *
+     * @param projectPath absolute path to the project root
+     * @param request     the reset request
+     * @throws IOException if the config file cannot be read or written
+     */
+    public static void resetDependencyOverrides(String projectPath, ResetConnectorDependencyRequest request)
+            throws IOException {
+
+        ConnectorConfig config = readConfig(projectPath);
+        ConnectorDependencyConfig connectorCfg = config.connectors.get(request.connectorArtifactId);
+        if (connectorCfg == null || connectorCfg.dependencies == null) {
+            return; // nothing to reset
+        }
+
+        if (request.connectionType != null) {
+            // Remove only the entry matching this connectionType
+            connectorCfg.dependencies.removeIf(
+                    o -> request.connectionType.equalsIgnoreCase(o.connectionType));
+        } else if (request.groupId != null && request.artifactId != null) {
+            // Remove the entry matching groupId+artifactId (for deps without connectionType)
+            connectorCfg.dependencies.removeIf(
+                    o -> o.connectionType == null
+                            && request.groupId.equals(o.groupId)
+                            && request.artifactId.equals(o.artifactId));
+        } else {
+            // Remove all overrides for this connector
+            config.connectors.remove(request.connectorArtifactId);
+        }
+        if (connectorCfg.dependencies != null && connectorCfg.dependencies.isEmpty()
+                && connectorCfg.omit == null && connectorCfg.omitAllDrivers == null) {
+            config.connectors.remove(request.connectorArtifactId);
+        }
+        writeConfig(projectPath, config);
+    }
+
+    // -------------------------------------------------------------------------
+    // Effective dependency computation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the effective dependency list for a single connector — descriptor.yml defaults
+     * merged with any overrides in connector-config.json.
+     *
+     * @param projectPath         absolute path to the project root
+     * @param connectorArtifactId connector Maven artifactId (e.g. "mi-connector-file")
+     * @return list of effective dependencies; empty if the connector has no descriptor.yml
+     */
+    public static List<EffectiveDependency> getEffectiveDependencies(String projectPath,
+                                                                     String connectorArtifactId) {
+
+        ConnectorConfig config = readConfig(projectPath);
+        List<Map<String, Object>> descriptorDeps = readDescriptorDependencies(connectorArtifactId);
+        return mergeDependencies(descriptorDeps, config, connectorArtifactId);
+    }
+
+    /**
+     * Returns the effective dependency lists for every connector currently loaded in the
+     * {@link ConnectorHolder}.
+     *
+     * @param projectPath absolute path to the project root
+     * @return map of connectorArtifactId → list of effective dependencies
+     */
+    public static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(String projectPath) {
+
+        ConnectorConfig config = readConfig(projectPath);
+        Map<String, ConnectorEffectiveData> result = new HashMap<>();
+
+        ConnectorHolder holder = ConnectorHolder.getInstance();
+        for (Connector connector : holder.getConnectors()) {
+            String artifactId = connectorArtifactId(connector);
+            List<Map<String, Object>> descriptorDeps = readDescriptorDependenciesFromPath(
+                    connector.getExtractedConnectorPath());
+            ConnectorDependencyConfig connectorCfg = config.connectors.get(artifactId);
+
+            ConnectorEffectiveData data = new ConnectorEffectiveData();
+            data.omit = Boolean.TRUE.equals(connectorCfg != null ? connectorCfg.omit : null);
+            data.omitAllDrivers = Boolean.TRUE.equals(config.omitAllDrivers)
+                    || Boolean.TRUE.equals(connectorCfg != null ? connectorCfg.omitAllDrivers : null);
+            if (descriptorDeps != null && !descriptorDeps.isEmpty()) {
+                data.dependencies = mergeDependencies(descriptorDeps, config, artifactId);
+            } else {
+                data.dependencies = new ArrayList<>();
+            }
+            result.put(artifactId, data);
+        }
+        return result;
+    }
+
+    /**
+     * Looks up a dependency override using the connector's short name (as held in {@link ConnectorHolder})
+     * and a connection type. This is used by {@code ConnectorDownloadManager} which receives the short
+     * connector name (e.g. "file") rather than the Maven artifactId (e.g. "mi-connector-file").
+     *
+     * <p>The lookup iterates over all connector entries in connector-config.json and returns the first
+     * override whose entry key ends with the given connectorName and whose connectionType matches.
+     *
+     * @param projectPath    absolute path to the project root
+     * @param connectorName  short connector name (e.g. "file", "amazonsqs")
+     * @param connectionType connection type from descriptor.yml (e.g. "MYSQL")
+     * @return the matching override, or {@code null} if none found
+     */
+    public static DependencyOverride findOverrideByConnectorNameAndConnectionType(String projectPath,
+                                                                                  String connectorName,
+                                                                                  String connectionType) {
+
+        ConnectorConfig config = readConfig(projectPath);
+        if (config.connectors == null || config.connectors.isEmpty()) {
+            return null;
+        }
+        for (Map.Entry<String, ConnectorDependencyConfig> entry : config.connectors.entrySet()) {
+            // Match by suffix: "mi-connector-file" ends with "-file"
+            String key = entry.getKey();
+            if (!key.equals(connectorName) && !key.endsWith("-" + connectorName)) {
+                continue;
+            }
+            ConnectorDependencyConfig cfg = entry.getValue();
+            if (cfg == null || cfg.dependencies == null) {
+                continue;
+            }
+            DependencyOverride match = findMatchingOverride(cfg.dependencies, connectionType, null, null);
+            if (match != null) {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static File configFile(String projectPath) {
+
+        return Path.of(projectPath, CONFIG_RELATIVE_PATH).toFile();
+    }
+
+    /**
+     * Reads the {@code dependencies} list from a connector's descriptor.yml using its
+     * ConnectorHolder name to locate the extracted path.
+     */
+    private static List<Map<String, Object>> readDescriptorDependencies(String connectorArtifactId) {
+
+        Connector connector = ConnectorHolder.getInstance().getConnectors().stream()
+                .filter(c -> connectorArtifactId.equals(connectorArtifactId(c)))
+                .findFirst().orElse(null);
+        if (connector == null) {
+            return Collections.emptyList();
+        }
+        return readDescriptorDependenciesFromPath(connector.getExtractedConnectorPath());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> readDescriptorDependenciesFromPath(String extractedConnectorPath) {
+
+        if (StringUtils.isBlank(extractedConnectorPath)) {
+            return Collections.emptyList();
+        }
+        File descriptorFile = new File(extractedConnectorPath, Constant.DESCRIPTOR_FILE);
+        if (!descriptorFile.exists()) {
+            return Collections.emptyList();
+        }
+        try (InputStream is = Files.newInputStream(descriptorFile.toPath())) {
+            Map<String, Object> yamlData = YAML_MAPPER.readValue(is, Map.class);
+            Object deps = yamlData.get("dependencies");
+            if (deps instanceof List) {
+                return (List<Map<String, Object>>) deps;
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to read descriptor.yml from " + extractedConnectorPath
+                    + ": " + e.getMessage());
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Merges descriptor.yml dependency entries with connector-config.json overrides.
+     */
+    private static List<EffectiveDependency> mergeDependencies(List<Map<String, Object>> descriptorDeps,
+                                                               ConnectorConfig config,
+                                                               String connectorArtifactId) {
+
+        ConnectorDependencyConfig connectorCfg = config.connectors.get(connectorArtifactId);
+        boolean globalOmitAllDrivers = Boolean.TRUE.equals(config.omitAllDrivers)
+                || (connectorCfg != null && Boolean.TRUE.equals(connectorCfg.omitAllDrivers));
+        List<DependencyOverride> overrides =
+                (connectorCfg != null && connectorCfg.dependencies != null)
+                        ? connectorCfg.dependencies
+                        : Collections.emptyList();
+
+        List<EffectiveDependency> result = new ArrayList<>();
+        for (Map<String, Object> dep : descriptorDeps) {
+            String groupId = (String) dep.get("groupId");
+            String artifactId = (String) dep.get("artifactId");
+            String version = (String) dep.get("version");
+            String connectionType = (String) dep.get("connectionType");
+
+            DependencyOverride override = findMatchingOverride(overrides, connectionType, groupId, artifactId);
+
+            EffectiveDependency eff = new EffectiveDependency();
+            eff.connectionType = connectionType;
+            eff.defaultVersion = version;
+            eff.groupId = groupId;
+            eff.artifactId = artifactId;
+
+            if (globalOmitAllDrivers) {
+                eff.omit = true;
+                eff.isOverridden = true;
+            } else if (override != null) {
+                eff.isOverridden = true;
+                eff.omit = Boolean.TRUE.equals(override.omit);
+                if (!StringUtils.isBlank(override.groupId)) {
+                    eff.groupId = override.groupId;
+                }
+                if (!StringUtils.isBlank(override.artifactId)) {
+                    eff.artifactId = override.artifactId;
+                }
+                if (!StringUtils.isBlank(override.version)) {
+                    eff.overriddenVersion = override.version;
+                }
+            }
+            result.add(eff);
+        }
+        return result;
+    }
+
+    /** Finds the best-matching override by connectionType, then by groupId+artifactId. */
+    private static DependencyOverride findMatchingOverride(List<DependencyOverride> overrides,
+                                                           String connectionType,
+                                                           String groupId, String artifactId) {
+
+        if (overrides == null) {
+            return null;
+        }
+        if (connectionType != null) {
+            for (DependencyOverride o : overrides) {
+                if (connectionType.equalsIgnoreCase(o.connectionType)) {
+                    return o;
+                }
+            }
+        }
+        if (groupId != null && artifactId != null) {
+            for (DependencyOverride o : overrides) {
+                if (o.connectionType == null
+                        && groupId.equals(o.groupId)
+                        && artifactId.equals(o.artifactId)) {
+                    return o;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Updates connector-level flags (omit, omitAllDrivers) for a specific connector.
+     *
+     * @param projectPath absolute path to the project root
+     * @param request     the flag update request
+     * @throws IOException if the config file cannot be read or written
+     */
+    public static void updateConnectorFlags(String projectPath, UpdateConnectorFlagsRequest request)
+            throws IOException {
+
+        ConnectorConfig config = readConfig(projectPath);
+        ConnectorDependencyConfig connectorCfg = config.connectors.computeIfAbsent(
+                request.connectorArtifactId, k -> new ConnectorDependencyConfig());
+
+        if (request.omit != null) {
+            connectorCfg.omit = request.omit ? Boolean.TRUE : null;
+        }
+        if (request.omitAllDrivers != null) {
+            connectorCfg.omitAllDrivers = request.omitAllDrivers ? Boolean.TRUE : null;
+        }
+
+        // If all fields on the connector config are now null/empty, remove the entry
+        if (connectorCfg.omit == null && connectorCfg.omitAllDrivers == null
+                && (connectorCfg.dependencies == null || connectorCfg.dependencies.isEmpty())) {
+            config.connectors.remove(request.connectorArtifactId);
+        }
+
+        writeConfig(projectPath, config);
+    }
+
+    /**
+     * Updates root-level flags (omitAllDrivers, omitAllConnectors) in connector-config.json.
+     *
+     * @param projectPath absolute path to the project root
+     * @param request     the root config update request
+     * @throws IOException if the config file cannot be read or written
+     */
+    public static void updateRootConfig(String projectPath, UpdateRootConfigRequest request)
+            throws IOException {
+
+        ConnectorConfig config = readConfig(projectPath);
+
+        if (request.omitAllDrivers != null) {
+            config.omitAllDrivers = request.omitAllDrivers ? Boolean.TRUE : null;
+        }
+        if (request.omitAllConnectors != null) {
+            config.omitAllConnectors = request.omitAllConnectors ? Boolean.TRUE : null;
+        }
+
+        writeConfig(projectPath, config);
+    }
+
+    /**
+     * Derives the Maven artifactId from a loaded Connector by inspecting its ZIP file name.
+     * Falls back to the connector's short name if no version suffix is found.
+     */
+    private static String connectorArtifactId(Connector connector) {
+
+        List<File> zips = ConnectorHolder.getInstance().getConnectorZips();
+        if (zips != null) {
+            for (File zip : zips) {
+                String name = zip.getName().replace(".zip", "");
+                Matcher m = ARTIFACT_ID_PATTERN.matcher(name);
+                if (m.matches()) {
+                    // Check if this ZIP corresponds to this connector by short name
+                    String candidateArtifactId = m.group(1);
+                    if (candidateArtifactId.endsWith("-" + connector.getName())
+                            || candidateArtifactId.equals(connector.getName())) {
+                        return candidateArtifactId;
+                    }
+                }
+            }
+        }
+        // Fallback
+        return connector.getName();
+    }
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorConfigService.java
@@ -131,11 +131,20 @@ public class ConnectorConfigService {
         // not support ATOMIC_MOVE (e.g. cross-device mounts).
         Path target = configFile.toPath();
         Path tmp = target.resolveSibling(configFile.getName() + ".tmp");
-        JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValue(tmp.toFile(), config);
         try {
-            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-        } catch (AtomicMoveNotSupportedException e) {
-            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValue(tmp.toFile(), config);
+            try {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            try {
+                Files.deleteIfExists(tmp);
+            } catch (IOException deleteEx) {
+                LOGGER.log(Level.WARNING, "Failed to delete temp file after write failure: " + tmp, deleteEx);
+            }
+            throw e;
         }
         LOGGER.log(Level.INFO, "connector-config.json written to: " + configFile.getAbsolutePath());
     }
@@ -218,7 +227,7 @@ public class ConnectorConfigService {
                     existing.version = blankToNull(request.version);
                 }
                 if (request.omit != null) {
-                    existing.omit = request.omit;
+                    existing.omit = request.omit ? Boolean.TRUE : null;
                 }
                 if (request.localPath != null) {
                     existing.localPath = blankToNull(request.localPath);
@@ -230,7 +239,7 @@ public class ConnectorConfigService {
                 override.groupId = blankToNull(request.groupId);
                 override.artifactId = blankToNull(request.artifactId);
                 override.version = blankToNull(request.version);
-                override.omit = request.omit;
+                override.omit = Boolean.TRUE.equals(request.omit) ? Boolean.TRUE : null;
                 override.localPath = blankToNull(request.localPath);
                 connectorCfg.dependencies.add(override);
             }
@@ -250,6 +259,10 @@ public class ConnectorConfigService {
      */
     public static void resetDependencyOverrides(String projectPath, ResetConnectorDependencyRequest request)
             throws IOException {
+
+        if (StringUtils.isBlank(request.connectorArtifactId)) {
+            throw new IllegalArgumentException("connectorArtifactId must not be blank");
+        }
 
         // Partial groupId/artifactId (only one provided) is ambiguous — treat as no-op
         boolean hasGroupId = !StringUtils.isBlank(request.groupId);
@@ -311,7 +324,9 @@ public class ConnectorConfigService {
         response.omitAllConnectors = Boolean.TRUE.equals(config.omitAllConnectors);
         if (connectorArtifactId != null) {
             List<Map<String, Object>> descriptorDeps = readDescriptorDependencies(connectorArtifactId);
-            response.dependencies = mergeDependencies(descriptorDeps, config, connectorArtifactId, projectPath);
+            Set<String> activeConnectionTypes = scanActiveConnectionTypes(projectPath);
+            response.dependencies = mergeDependencies(descriptorDeps, config, connectorArtifactId,
+                    activeConnectionTypes);
         } else {
             response.allConnectors = getAllEffectiveDependencies(config, projectPath);
         }
@@ -329,6 +344,10 @@ public class ConnectorConfigService {
     private static Map<String, ConnectorEffectiveData> getAllEffectiveDependencies(ConnectorConfig config,
                                                                                    String projectPath) {
 
+        // Scan once here; the set is forwarded to mergeDependencies so it is not re-scanned
+        // for every connector in the loop below.
+        Set<String> activeConnectionTypes = scanActiveConnectionTypes(projectPath);
+
         Map<String, ConnectorEffectiveData> result = new HashMap<>();
         ConnectorHolder holder = ConnectorHolder.getInstance();
         for (Connector connector : new ArrayList<>(holder.getConnectors())) {
@@ -343,7 +362,7 @@ public class ConnectorConfigService {
                     || Boolean.TRUE.equals(connectorCfg != null ? connectorCfg.omitAllDrivers : null);
             data.dependencies = descriptorDeps.isEmpty()
                     ? new ArrayList<>()
-                    : mergeDependencies(descriptorDeps, config, artifactId, projectPath);
+                    : mergeDependencies(descriptorDeps, config, artifactId, activeConnectionTypes);
             result.put(artifactId, data);
         }
         return result;
@@ -455,13 +474,13 @@ public class ConnectorConfigService {
 
     /**
      * Merges descriptor.yml dependency entries with connector-config.json overrides.
-     * Also sets {@link EffectiveDependency#isConnectionTypeActive} by scanning the project's
-     * local entries to find which connectionTypes are in use.
+     * Also sets {@link EffectiveDependency#isConnectionTypeActive} using the supplied pre-computed
+     * set of active connectionTypes so callers avoid re-scanning the local-entries directory.
      */
     private static List<EffectiveDependency> mergeDependencies(List<Map<String, Object>> descriptorDeps,
                                                                ConnectorConfig config,
                                                                String connectorArtifactId,
-                                                               String projectPath) {
+                                                               Set<String> activeConnectionTypes) {
 
         ConnectorDependencyConfig connectorCfg = findConnectorConfig(config, connectorArtifactId);
         boolean globalOmitAllDrivers = Boolean.TRUE.equals(config.omitAllDrivers)
@@ -470,8 +489,6 @@ public class ConnectorConfigService {
                 (connectorCfg != null && connectorCfg.dependencies != null)
                         ? connectorCfg.dependencies
                         : Collections.emptyList();
-
-        Set<String> activeConnectionTypes = scanActiveConnectionTypes(projectPath);
 
         List<EffectiveDependency> result = new ArrayList<>();
         for (Map<String, Object> dep : descriptorDeps) {
@@ -489,7 +506,7 @@ public class ConnectorConfigService {
             eff.artifactId = artifactId;
             // Deps without a connectionType are always "active"; those with one are active only
             // when a local entry uses that connectionType.
-            eff.isConnectionTypeActive = (connectionType == null) || activeConnectionTypes.contains(connectionType);
+            eff.isConnectionTypeActive = (connectionType == null) || activeConnectionTypes.contains(connectionType.toUpperCase());
 
             if (globalOmitAllDrivers) {
                 eff.omit = true;
@@ -556,7 +573,7 @@ public class ConnectorConfigService {
                             if (ctNodes.getLength() > 0) {
                                 String ct = ctNodes.item(0).getTextContent().trim();
                                 if (!ct.isEmpty()) {
-                                    active.add(ct);
+                                    active.add(ct.toUpperCase());
                                 }
                             }
                             break;
@@ -661,45 +678,13 @@ public class ConnectorConfigService {
         }
     }
 
-    /**
-     * Looks up a connector's dependency config by its canonical Maven artifact ID.
-     *
-     * <p>As a backward-compatibility measure, if no exact match is found the method merges all
-     * entries whose key matches by suffix (e.g. both "db" and "mi-connector-db"), so that existing
-     * config files written before the canonical-key convention are still honoured.
-     */
-    private static ConnectorDependencyConfig findConnectorConfig(ConnectorConfig config, String canonicalArtifactId) {
+    /** Returns the connector's dependency config keyed by its Maven artifact ID, or null. */
+    private static ConnectorDependencyConfig findConnectorConfig(ConnectorConfig config, String artifactId) {
 
         if (config.connectors == null) {
             return null;
         }
-        // Fast path: canonical key present
-        ConnectorDependencyConfig exact = config.connectors.get(canonicalArtifactId);
-        if (exact != null) {
-            return exact;
-        }
-        // Backward-compat: collect all entries that refer to the same connector under old key forms
-        List<ConnectorDependencyConfig> matches = new ArrayList<>();
-        for (Map.Entry<String, ConnectorDependencyConfig> entry : config.connectors.entrySet()) {
-            String key = entry.getKey();
-            if (key.endsWith("-" + canonicalArtifactId) || canonicalArtifactId.endsWith("-" + key)) {
-                matches.add(entry.getValue());
-            }
-        }
-        if (matches.isEmpty()) {
-            return null;
-        }
-        if (matches.size() == 1) {
-            return matches.get(0);
-        }
-        ConnectorDependencyConfig merged = new ConnectorDependencyConfig();
-        merged.dependencies = new ArrayList<>();
-        for (ConnectorDependencyConfig cfg : matches) {
-            if (cfg.omit != null) merged.omit = cfg.omit;
-            if (cfg.omitAllDrivers != null) merged.omitAllDrivers = cfg.omitAllDrivers;
-            if (cfg.dependencies != null) merged.dependencies.addAll(cfg.dependencies);
-        }
-        return merged;
+        return config.connectors.get(artifactId);
     }
 
     /** Returns {@code null} when the value is null or blank; otherwise returns the value as-is. */

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyConfig.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -31,6 +31,13 @@ public class ConnectorDependencyConfig {
      * Overrides all per-dependency settings for this connector but does not affect other connectors.
      */
     public Boolean omitAllDrivers;
+
+    /**
+     * The connector's QName in {@code {package}name} form (e.g. {@code {org.wso2.connector}db}).
+     * Written by the language server so the CAR plugin can look up this entry by the lib-directory
+     * name, which is derived from the QName rather than the Maven artifact ID.
+     */
+    public String qname;
 
     public List<DependencyOverride> dependencies;
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyConfig.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+import java.util.List;
+
+/**
+ * Per-connector entry in connector-config.json.
+ */
+public class ConnectorDependencyConfig {
+
+    /**
+     * When true, this connector's ZIP will not be packed into the CAR.
+     */
+    public Boolean omit;
+
+    /**
+     * When true, no driver JARs for this connector will be packed into the CAR.
+     * Overrides all per-dependency settings for this connector but does not affect other connectors.
+     */
+    public Boolean omitAllDrivers;
+
+    public List<DependencyOverride> dependencies;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+/**
+ * Request to retrieve effective connector dependencies.
+ * When {@code connectorArtifactId} is null, all connectors in the project are returned.
+ */
+public class ConnectorDependencyRequest {
+
+    /** Connector Maven artifactId (e.g. "mi-connector-file"). Null means "all connectors". */
+    public String connectorArtifactId;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyResponse.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyResponse.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorDependencyResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Response containing effective connector dependencies plus root-level config flags.
+ */
+public class ConnectorDependencyResponse {
+
+    /** True when omitAllDrivers is set at the root level of connector-config.json. */
+    public boolean omitAllDrivers;
+
+    /** True when omitAllConnectors is set at the root level of connector-config.json. */
+    public boolean omitAllConnectors;
+
+    /** Populated when a single connector was requested. */
+    public List<EffectiveDependency> dependencies;
+
+    /**
+     * Populated when all connectors were requested.
+     * Key: connector artifactId, Value: its effective data (flags + dependencies).
+     */
+    public Map<String, ConnectorEffectiveData> allConnectors;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorEffectiveData.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorEffectiveData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorEffectiveData.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ConnectorEffectiveData.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+import java.util.List;
+
+/**
+ * Effective per-connector data returned in the VS Code extension response.
+ * Includes the connector-level flags and the merged effective dependency list.
+ */
+public class ConnectorEffectiveData {
+
+    /** True when this connector's ZIP will not be packed into the CAR. */
+    public boolean omit;
+
+    /** True when all driver JARs for this connector will not be packed. */
+    public boolean omitAllDrivers;
+
+    /** The merged effective dependencies (descriptor.yml defaults + overrides). */
+    public List<EffectiveDependency> dependencies;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/DependencyOverride.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/DependencyOverride.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+/**
+ * Represents a single dependency override entry in connector-config.json.
+ * A match is attempted first by connectionType, then by groupId + artifactId.
+ */
+public class DependencyOverride {
+
+    public String connectionType;
+    public String groupId;
+    public String artifactId;
+    public String version;
+    public Boolean omit;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/DependencyOverride.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/DependencyOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -25,4 +25,6 @@ public class DependencyOverride {
     public String artifactId;
     public String version;
     public Boolean omit;
+    /** Absolute path to a local JAR. When set, Maven download is skipped and this file is used directly. */
+    public String localPath;
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/EffectiveDependency.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/EffectiveDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -47,4 +47,14 @@ public class EffectiveDependency {
      * default — i.e., when the user has an active override for this dependency.
      */
     public boolean isOverridden;
+
+    /**
+     * True when there is at least one local entry that uses this connectionType.
+     * False for deps without a connectionType (always considered active).
+     * Populated by the language server by scanning project local entries.
+     */
+    public boolean isConnectionTypeActive;
+
+    /** Absolute path to a local JAR override, or null when not set. */
+    public String localPath;
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/EffectiveDependency.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/EffectiveDependency.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+/**
+ * The merged view of a single connector dependency — descriptor.yml defaults overlaid with
+ * any user overrides from connector-config.json. This is what the VS Code extension renders
+ * in the dependency management UI.
+ */
+public class EffectiveDependency {
+
+    /** Connection type from descriptor.yml (may be null for non-connection-typed deps). */
+    public String connectionType;
+
+    /** Effective groupId (override if set, else descriptor.yml default). */
+    public String groupId;
+
+    /** Effective artifactId (override if set, else descriptor.yml default). */
+    public String artifactId;
+
+    /** The version declared in descriptor.yml (the connector's tested/recommended version). */
+    public String defaultVersion;
+
+    /**
+     * The version from connector-config.json override, or null if no version override is set.
+     * When non-null, this is what the build will use instead of defaultVersion.
+     */
+    public String overriddenVersion;
+
+    /** True when this dependency is excluded from the CAR via connector-config.json. */
+    public boolean omit;
+
+    /**
+     * True when any field (version, groupId, artifactId, or omit) differs from the descriptor.yml
+     * default — i.e., when the user has an active override for this dependency.
+     */
+    public boolean isOverridden;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ResetConnectorDependencyRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ResetConnectorDependencyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ResetConnectorDependencyRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/ResetConnectorDependencyRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+/**
+ * Request to remove dependency overrides from connector-config.json.
+ * When connectionType is null, all overrides for the connector are removed.
+ */
+public class ResetConnectorDependencyRequest {
+
+    /** Required. Connector Maven artifactId (e.g. "mi-connector-file"). */
+    public String connectorArtifactId;
+
+    /**
+     * When set, removes only the override matching this connectionType.
+     * When null with no groupId/artifactId, removes all overrides for the connector.
+     */
+    public String connectionType;
+
+    /**
+     * Used to identify a specific dep when connectionType is null.
+     * Both groupId and artifactId must be set together.
+     */
+    public String groupId;
+    public String artifactId;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorDependencyRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorDependencyRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -37,4 +37,7 @@ public class UpdateConnectorDependencyRequest {
 
     /** When true, excludes this dependency from the CAR. */
     public Boolean omit;
+
+    /** Absolute path to a local JAR. When set, Maven download is skipped. */
+    public String localPath;
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorDependencyRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorDependencyRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+/**
+ * Request to add or update a dependency override in connector-config.json.
+ * Fields that are null leave the corresponding values unchanged (or unset for new entries).
+ */
+public class UpdateConnectorDependencyRequest {
+
+    /** Required. Connector Maven artifactId (e.g. "mi-connector-file"). */
+    public String connectorArtifactId;
+
+    /** Matches by connectionType when non-null. */
+    public String connectionType;
+
+    /** Override groupId. Null means "no groupId override". */
+    public String groupId;
+
+    /** Override artifactId. Null means "no artifactId override". */
+    public String artifactId;
+
+    /** Override version. Null means "no version override". */
+    public String version;
+
+    /** When true, excludes this dependency from the CAR. */
+    public Boolean omit;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorFlagsRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorFlagsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorFlagsRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorFlagsRequest.java
@@ -19,8 +19,6 @@ package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
  */
 public class UpdateConnectorFlagsRequest {
 
-    public String projectPath;
-
     /** The connector Maven artifactId (e.g. "mi-connector-file"). */
     public String connectorArtifactId;
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorFlagsRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateConnectorFlagsRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+/**
+ * Request to update connector-level flags (omit, omitAllDrivers) for a specific connector.
+ */
+public class UpdateConnectorFlagsRequest {
+
+    public String projectPath;
+
+    /** The connector Maven artifactId (e.g. "mi-connector-file"). */
+    public String connectorArtifactId;
+
+    /** When non-null, sets whether this connector's ZIP is excluded from the CAR. */
+    public Boolean omit;
+
+    /** When non-null, sets whether all drivers for this connector are excluded from the CAR. */
+    public Boolean omitAllDrivers;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateGlobalConnectorFlagsRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateGlobalConnectorFlagsRequest.java
@@ -19,8 +19,6 @@ package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
  */
 public class UpdateGlobalConnectorFlagsRequest {
 
-    public String projectPath;
-
     /** When non-null, sets whether all driver JARs are omitted globally. */
     public Boolean omitAllDrivers;
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateGlobalConnectorFlagsRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateGlobalConnectorFlagsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -15,9 +15,9 @@
 package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
 
 /**
- * Request to update root-level flags in connector-config.json.
+ * Request to update global connector flags in connector-config.json.
  */
-public class UpdateRootConfigRequest {
+public class UpdateGlobalConnectorFlagsRequest {
 
     public String projectPath;
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateRootConfigRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/connectorConfig/UpdateRootConfigRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.customservice.synapse.parser.connectorConfig;
+
+/**
+ * Request to update root-level flags in connector-config.json.
+ */
+public class UpdateRootConfigRequest {
+
+    public String projectPath;
+
+    /** When non-null, sets whether all driver JARs are omitted globally. */
+    public Boolean omitAllDrivers;
+
+    /** When non-null, sets whether all connector ZIPs are excluded from the CAR globally. */
+    public Boolean omitAllConnectors;
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/config/ConnectorConfigServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/config/ConnectorConfigServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -16,9 +16,12 @@ package org.eclipse.lemminx.synapse.connector.config;
 
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorConfig;
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorConfigService;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorDependencyConfig;
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.DependencyOverride;
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ResetConnectorDependencyRequest;
 import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorDependencyRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorFlagsRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateGlobalConnectorFlagsRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -31,6 +34,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConnectorConfigServiceTest {
@@ -188,6 +192,52 @@ public class ConnectorConfigServiceTest {
     }
 
     @Test
+    public void testUpdateDependencyOverride_BlankStringFieldsNormalizedToNullOnAdd() throws IOException {
+        UpdateConnectorDependencyRequest req = new UpdateConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-db";
+        req.connectionType = "MYSQL";
+        req.version = "  "; // blank — should become null
+        req.groupId = "";   // blank — should become null
+
+        ConnectorConfigService.updateDependencyOverride(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        DependencyOverride dep = config.connectors.get("mi-connector-db").dependencies.get(0);
+        assertEquals("MYSQL", dep.connectionType);
+        assertNull(dep.version);
+        assertNull(dep.groupId);
+    }
+
+    @Test
+    public void testUpdateDependencyOverride_BlankStringFieldsNormalizedToNullOnUpdate() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-db\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\", \"groupId\": \"com.mysql\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        UpdateConnectorDependencyRequest req = new UpdateConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-db";
+        req.connectionType = "MYSQL";
+        req.version = "  "; // blank — should clear the existing version to null
+        req.groupId = "";   // blank — should clear the existing groupId to null
+
+        ConnectorConfigService.updateDependencyOverride(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        DependencyOverride dep = config.connectors.get("mi-connector-db").dependencies.get(0);
+        assertNull(dep.version);
+        assertNull(dep.groupId);
+    }
+
+    @Test
     public void testUpdateDependencyOverride_AddsSecondOverrideForDifferentConnectionType() throws IOException {
         writeConfigFile(
                 "{\n" +
@@ -308,6 +358,210 @@ public class ConnectorConfigServiceTest {
 
         // Should not throw
         ConnectorConfigService.resetDependencyOverrides(tempDir.toString(), req);
+    }
+
+    // -------------------------------------------------------------------------
+    // updateConnectorFlags
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testUpdateConnectorFlags_ThrowsWhenArtifactIdIsNull() {
+        UpdateConnectorFlagsRequest req = new UpdateConnectorFlagsRequest();
+        req.connectorArtifactId = null;
+        req.omit = true;
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ConnectorConfigService.updateConnectorFlags(tempDir.toString(), req));
+    }
+
+    @Test
+    public void testUpdateConnectorFlags_ThrowsWhenArtifactIdIsBlank() {
+        UpdateConnectorFlagsRequest req = new UpdateConnectorFlagsRequest();
+        req.connectorArtifactId = "   ";
+        req.omit = true;
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ConnectorConfigService.updateConnectorFlags(tempDir.toString(), req));
+    }
+
+    @Test
+    public void testUpdateConnectorFlags_SetsOmitTrue() throws IOException {
+        UpdateConnectorFlagsRequest req = new UpdateConnectorFlagsRequest();
+        req.connectorArtifactId = "mi-connector-db";
+        req.omit = true;
+
+        ConnectorConfigService.updateConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        ConnectorDependencyConfig cfg = config.connectors.get("mi-connector-db");
+        assertNotNull(cfg);
+        assertEquals(Boolean.TRUE, cfg.omit);
+        assertNull(cfg.omitAllDrivers);
+    }
+
+    @Test
+    public void testUpdateConnectorFlags_SetsOmitAllDriversTrue() throws IOException {
+        UpdateConnectorFlagsRequest req = new UpdateConnectorFlagsRequest();
+        req.connectorArtifactId = "mi-connector-db";
+        req.omitAllDrivers = true;
+
+        ConnectorConfigService.updateConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        ConnectorDependencyConfig cfg = config.connectors.get("mi-connector-db");
+        assertNotNull(cfg);
+        assertEquals(Boolean.TRUE, cfg.omitAllDrivers);
+        assertNull(cfg.omit);
+    }
+
+    @Test
+    public void testUpdateConnectorFlags_ClearingFlagRemovesConnectorEntryWhenNothingElseSet() throws IOException {
+        // Start with only omit=true — no dependencies
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-db\": { \"omit\": true }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        UpdateConnectorFlagsRequest req = new UpdateConnectorFlagsRequest();
+        req.connectorArtifactId = "mi-connector-db";
+        req.omit = false; // clear it
+
+        ConnectorConfigService.updateConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        // All fields are now null/empty — the connector key must be pruned
+        assertNull(config.connectors.get("mi-connector-db"));
+    }
+
+    @Test
+    public void testUpdateConnectorFlags_ClearingOneFlag_RetainsOtherFlag() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-db\": { \"omit\": true, \"omitAllDrivers\": true }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        UpdateConnectorFlagsRequest req = new UpdateConnectorFlagsRequest();
+        req.connectorArtifactId = "mi-connector-db";
+        req.omit = false; // clear omit, leave omitAllDrivers
+
+        ConnectorConfigService.updateConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        ConnectorDependencyConfig cfg = config.connectors.get("mi-connector-db");
+        assertNotNull(cfg);
+        assertNull(cfg.omit);
+        assertEquals(Boolean.TRUE, cfg.omitAllDrivers);
+    }
+
+    @Test
+    public void testUpdateConnectorFlags_ConnectorEntryKeptWhenDependenciesRemain() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-db\": {\n" +
+                "      \"omit\": true,\n" +
+                "      \"dependencies\": [ { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" } ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        UpdateConnectorFlagsRequest req = new UpdateConnectorFlagsRequest();
+        req.connectorArtifactId = "mi-connector-db";
+        req.omit = false; // clear omit — dependencies still present
+
+        ConnectorConfigService.updateConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        ConnectorDependencyConfig cfg = config.connectors.get("mi-connector-db");
+        assertNotNull(cfg);
+        assertNull(cfg.omit);
+        assertNotNull(cfg.dependencies);
+        assertEquals(1, cfg.dependencies.size());
+    }
+
+    // -------------------------------------------------------------------------
+    // updateGlobalConnectorFlags
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testUpdateGlobalConnectorFlags_SetsOmitAllDrivers() throws IOException {
+        UpdateGlobalConnectorFlagsRequest req = new UpdateGlobalConnectorFlagsRequest();
+        req.projectPath = tempDir.toString();
+        req.omitAllDrivers = true;
+
+        ConnectorConfigService.updateGlobalConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        assertEquals(Boolean.TRUE, config.omitAllDrivers);
+        assertNull(config.omitAllConnectors);
+    }
+
+    @Test
+    public void testUpdateGlobalConnectorFlags_SetsOmitAllConnectors() throws IOException {
+        UpdateGlobalConnectorFlagsRequest req = new UpdateGlobalConnectorFlagsRequest();
+        req.projectPath = tempDir.toString();
+        req.omitAllConnectors = true;
+
+        ConnectorConfigService.updateGlobalConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        assertEquals(Boolean.TRUE, config.omitAllConnectors);
+        assertNull(config.omitAllDrivers);
+    }
+
+    @Test
+    public void testUpdateGlobalConnectorFlags_ClearsBothFlags() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"omitAllDrivers\": true,\n" +
+                "  \"omitAllConnectors\": true,\n" +
+                "  \"connectors\": {}\n" +
+                "}"
+        );
+
+        UpdateGlobalConnectorFlagsRequest req = new UpdateGlobalConnectorFlagsRequest();
+        req.projectPath = tempDir.toString();
+        req.omitAllDrivers = false;
+        req.omitAllConnectors = false;
+
+        ConnectorConfigService.updateGlobalConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        assertNull(config.omitAllDrivers);
+        assertNull(config.omitAllConnectors);
+    }
+
+    @Test
+    public void testUpdateGlobalConnectorFlags_NullRequestFieldsAreNoOp() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"omitAllDrivers\": true,\n" +
+                "  \"connectors\": {}\n" +
+                "}"
+        );
+
+        // Only set omitAllConnectors — omitAllDrivers must be left untouched
+        UpdateGlobalConnectorFlagsRequest req = new UpdateGlobalConnectorFlagsRequest();
+        req.projectPath = tempDir.toString();
+        req.omitAllConnectors = true;
+
+        ConnectorConfigService.updateGlobalConnectorFlags(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        assertEquals(Boolean.TRUE, config.omitAllDrivers);
+        assertEquals(Boolean.TRUE, config.omitAllConnectors);
     }
 
     // -------------------------------------------------------------------------

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/config/ConnectorConfigServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/config/ConnectorConfigServiceTest.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -86,7 +85,7 @@ public class ConnectorConfigServiceTest {
 
         ConnectorConfigService.writeConfig(tempDir.toString(), config);
 
-        File written = tempDir.resolve("src/main/wso2mi/connector-config.json").toFile();
+        File written = tempDir.resolve("src/main/wso2mi/resources/connectors/connector-config.json").toFile();
         assertTrue(written.exists());
 
         ConnectorConfig readBack = ConnectorConfigService.readConfig(tempDir.toString());
@@ -102,7 +101,7 @@ public class ConnectorConfigServiceTest {
     public void testInitIfAbsent_CreatesFileWhenAbsent() {
         ConnectorConfigService.initIfAbsent(tempDir.toString());
 
-        File written = tempDir.resolve("src/main/wso2mi/connector-config.json").toFile();
+        File written = tempDir.resolve("src/main/wso2mi/resources/connectors/connector-config.json").toFile();
         assertTrue(written.exists());
     }
 
@@ -375,7 +374,7 @@ public class ConnectorConfigServiceTest {
     // -------------------------------------------------------------------------
 
     private void writeConfigFile(String content) throws IOException {
-        File dir = tempDir.resolve("src/main/wso2mi").toFile();
+        File dir = tempDir.resolve("src/main/wso2mi/resources/connectors").toFile();
         dir.mkdirs();
         try (FileWriter w = new FileWriter(new File(dir, "connector-config.json"))) {
             w.write(content);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/config/ConnectorConfigServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/config/ConnectorConfigServiceTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.synapse.connector.config;
+
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorConfig;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ConnectorConfigService;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.DependencyOverride;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.ResetConnectorDependencyRequest;
+import org.eclipse.lemminx.customservice.synapse.parser.connectorConfig.UpdateConnectorDependencyRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConnectorConfigServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    // -------------------------------------------------------------------------
+    // readConfig
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testReadConfig_ReturnsEmptyConfigWhenFileAbsent() {
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        assertNotNull(config);
+        assertEquals("1.0", config.version);
+        assertNotNull(config.connectors);
+        assertTrue(config.connectors.isEmpty());
+    }
+
+    @Test
+    public void testReadConfig_ParsesExistingFile() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        assertNotNull(config.connectors.get("mi-connector-file"));
+        List<DependencyOverride> deps = config.connectors.get("mi-connector-file").dependencies;
+        assertEquals(1, deps.size());
+        assertEquals("MYSQL", deps.get(0).connectionType);
+        assertEquals("9.0.0", deps.get(0).version);
+    }
+
+    // -------------------------------------------------------------------------
+    // writeConfig + round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWriteConfig_CreatesFileAndCanBeReadBack() throws IOException {
+        ConnectorConfig config = new ConnectorConfig();
+        config.version = "1.0";
+
+        ConnectorConfigService.writeConfig(tempDir.toString(), config);
+
+        File written = tempDir.resolve("src/main/wso2mi/connector-config.json").toFile();
+        assertTrue(written.exists());
+
+        ConnectorConfig readBack = ConnectorConfigService.readConfig(tempDir.toString());
+        assertNotNull(readBack);
+        assertEquals("1.0", readBack.version);
+    }
+
+    // -------------------------------------------------------------------------
+    // initIfAbsent
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testInitIfAbsent_CreatesFileWhenAbsent() {
+        ConnectorConfigService.initIfAbsent(tempDir.toString());
+
+        File written = tempDir.resolve("src/main/wso2mi/connector-config.json").toFile();
+        assertTrue(written.exists());
+    }
+
+    @Test
+    public void testInitIfAbsent_DoesNotOverwriteExistingFile() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": { \"dependencies\": [] }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        ConnectorConfigService.initIfAbsent(tempDir.toString());
+
+        // Existing data should still be there
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        assertTrue(config.connectors.containsKey("mi-connector-file"));
+    }
+
+    // -------------------------------------------------------------------------
+    // updateDependencyOverride — add new override
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testUpdateDependencyOverride_AddsNewOverrideToEmptyConfig() throws IOException {
+        UpdateConnectorDependencyRequest req = new UpdateConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-file";
+        req.connectionType = "MYSQL";
+        req.version = "9.0.0";
+
+        ConnectorConfigService.updateDependencyOverride(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        List<DependencyOverride> deps = config.connectors.get("mi-connector-file").dependencies;
+        assertEquals(1, deps.size());
+        assertEquals("MYSQL", deps.get(0).connectionType);
+        assertEquals("9.0.0", deps.get(0).version);
+    }
+
+    @Test
+    public void testUpdateDependencyOverride_UpdatesExistingOverrideByConnectionType() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"8.0.33\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        UpdateConnectorDependencyRequest req = new UpdateConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-file";
+        req.connectionType = "MYSQL";
+        req.version = "9.0.0";
+
+        ConnectorConfigService.updateDependencyOverride(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        List<DependencyOverride> deps = config.connectors.get("mi-connector-file").dependencies;
+        // Should update in-place, not add a second entry
+        assertEquals(1, deps.size());
+        assertEquals("9.0.0", deps.get(0).version);
+    }
+
+    @Test
+    public void testUpdateDependencyOverride_SetsOmitTrue() throws IOException {
+        UpdateConnectorDependencyRequest req = new UpdateConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-file";
+        req.connectionType = "SFTP";
+        req.omit = true;
+
+        ConnectorConfigService.updateDependencyOverride(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        DependencyOverride dep = config.connectors.get("mi-connector-file").dependencies.get(0);
+        assertEquals(Boolean.TRUE, dep.omit);
+        assertEquals("SFTP", dep.connectionType);
+    }
+
+    @Test
+    public void testUpdateDependencyOverride_AddsSecondOverrideForDifferentConnectionType() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        UpdateConnectorDependencyRequest req = new UpdateConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-file";
+        req.connectionType = "SFTP";
+        req.omit = true;
+
+        ConnectorConfigService.updateDependencyOverride(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        List<DependencyOverride> deps = config.connectors.get("mi-connector-file").dependencies;
+        assertEquals(2, deps.size());
+    }
+
+    // -------------------------------------------------------------------------
+    // resetDependencyOverrides
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testResetDependencyOverrides_RemovesSpecificConnectionType() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" },\n" +
+                "        { \"connectionType\": \"SFTP\", \"omit\": true }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        ResetConnectorDependencyRequest req = new ResetConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-file";
+        req.connectionType = "SFTP";
+
+        ConnectorConfigService.resetDependencyOverrides(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        List<DependencyOverride> deps = config.connectors.get("mi-connector-file").dependencies;
+        assertEquals(1, deps.size());
+        assertEquals("MYSQL", deps.get(0).connectionType);
+    }
+
+    @Test
+    public void testResetDependencyOverrides_RemovesAllOverridesForConnector() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" },\n" +
+                "        { \"connectionType\": \"SFTP\", \"omit\": true }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        ResetConnectorDependencyRequest req = new ResetConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-file";
+        req.connectionType = null; // null = reset all
+
+        ConnectorConfigService.resetDependencyOverrides(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        assertNull(config.connectors.get("mi-connector-file"));
+    }
+
+    @Test
+    public void testResetDependencyOverrides_RemovesEntireConnectorKeyWhenLastOverrideRemoved() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        ResetConnectorDependencyRequest req = new ResetConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-file";
+        req.connectionType = "MYSQL";
+
+        ConnectorConfigService.resetDependencyOverrides(tempDir.toString(), req);
+
+        ConnectorConfig config = ConnectorConfigService.readConfig(tempDir.toString());
+        // When the last override is removed the connector key itself is cleaned up
+        assertNull(config.connectors.get("mi-connector-file"));
+    }
+
+    @Test
+    public void testResetDependencyOverrides_NoOpWhenConnectorNotInConfig() throws IOException {
+        writeConfigFile("{ \"version\": \"1.0\", \"connectors\": {} }");
+
+        ResetConnectorDependencyRequest req = new ResetConnectorDependencyRequest();
+        req.connectorArtifactId = "mi-connector-nonexistent";
+        req.connectionType = null;
+
+        // Should not throw
+        ConnectorConfigService.resetDependencyOverrides(tempDir.toString(), req);
+    }
+
+    // -------------------------------------------------------------------------
+    // findOverrideByConnectorNameAndConnectionType
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFindOverrideByConnectorName_MatchesBySuffix() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        // ConnectorHolder name is "file", artifactId in config is "mi-connector-file"
+        DependencyOverride result = ConnectorConfigService.findOverrideByConnectorNameAndConnectionType(
+                tempDir.toString(), "file", "MYSQL");
+
+        assertNotNull(result);
+        assertEquals("9.0.0", result.version);
+    }
+
+    @Test
+    public void testFindOverrideByConnectorName_ReturnsNullWhenNoMatch() throws IOException {
+        writeConfigFile("{ \"version\": \"1.0\", \"connectors\": {} }");
+
+        DependencyOverride result = ConnectorConfigService.findOverrideByConnectorNameAndConnectionType(
+                tempDir.toString(), "file", "MYSQL");
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testFindOverrideByConnectorName_OmitOverride() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-db\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"ORACLE\", \"omit\": true }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        DependencyOverride result = ConnectorConfigService.findOverrideByConnectorNameAndConnectionType(
+                tempDir.toString(), "db", "ORACLE");
+
+        assertNotNull(result);
+        assertEquals(Boolean.TRUE, result.omit);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void writeConfigFile(String content) throws IOException {
+        File dir = tempDir.resolve("src/main/wso2mi").toFile();
+        dir.mkdirs();
+        try (FileWriter w = new FileWriter(new File(dir, "connector-config.json"))) {
+            w.write(content);
+        }
+    }
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/config/ConnectorConfigServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/config/ConnectorConfigServiceTest.java
@@ -269,6 +269,15 @@ public class ConnectorConfigServiceTest {
     // -------------------------------------------------------------------------
 
     @Test
+    public void testResetDependencyOverrides_ThrowsWhenArtifactIdIsBlank() {
+        ResetConnectorDependencyRequest req = new ResetConnectorDependencyRequest();
+        req.connectorArtifactId = "  ";
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ConnectorConfigService.resetDependencyOverrides(tempDir.toString(), req));
+    }
+
+    @Test
     public void testResetDependencyOverrides_RemovesSpecificConnectionType() throws IOException {
         writeConfigFile(
                 "{\n" +
@@ -496,7 +505,6 @@ public class ConnectorConfigServiceTest {
     @Test
     public void testUpdateGlobalConnectorFlags_SetsOmitAllDrivers() throws IOException {
         UpdateGlobalConnectorFlagsRequest req = new UpdateGlobalConnectorFlagsRequest();
-        req.projectPath = tempDir.toString();
         req.omitAllDrivers = true;
 
         ConnectorConfigService.updateGlobalConnectorFlags(tempDir.toString(), req);
@@ -509,7 +517,6 @@ public class ConnectorConfigServiceTest {
     @Test
     public void testUpdateGlobalConnectorFlags_SetsOmitAllConnectors() throws IOException {
         UpdateGlobalConnectorFlagsRequest req = new UpdateGlobalConnectorFlagsRequest();
-        req.projectPath = tempDir.toString();
         req.omitAllConnectors = true;
 
         ConnectorConfigService.updateGlobalConnectorFlags(tempDir.toString(), req);
@@ -531,7 +538,6 @@ public class ConnectorConfigServiceTest {
         );
 
         UpdateGlobalConnectorFlagsRequest req = new UpdateGlobalConnectorFlagsRequest();
-        req.projectPath = tempDir.toString();
         req.omitAllDrivers = false;
         req.omitAllConnectors = false;
 
@@ -554,7 +560,6 @@ public class ConnectorConfigServiceTest {
 
         // Only set omitAllConnectors — omitAllDrivers must be left untouched
         UpdateGlobalConnectorFlagsRequest req = new UpdateGlobalConnectorFlagsRequest();
-        req.projectPath = tempDir.toString();
         req.omitAllConnectors = true;
 
         ConnectorConfigService.updateGlobalConnectorFlags(tempDir.toString(), req);
@@ -569,7 +574,7 @@ public class ConnectorConfigServiceTest {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testFindOverrideByConnectorName_MatchesBySuffix() throws IOException {
+    public void testFindOverrideByConnectorName_MatchesByArtifactId() throws IOException {
         writeConfigFile(
                 "{\n" +
                 "  \"version\": \"1.0\",\n" +
@@ -583,9 +588,8 @@ public class ConnectorConfigServiceTest {
                 "}"
         );
 
-        // ConnectorHolder name is "file", artifactId in config is "mi-connector-file"
         DependencyOverride result = ConnectorConfigService.findOverrideByConnectorNameAndConnectionType(
-                tempDir.toString(), "file", "MYSQL");
+                tempDir.toString(), "mi-connector-file", "MYSQL");
 
         assertNotNull(result);
         assertEquals("9.0.0", result.version);
@@ -617,7 +621,7 @@ public class ConnectorConfigServiceTest {
         );
 
         DependencyOverride result = ConnectorConfigService.findOverrideByConnectorNameAndConnectionType(
-                tempDir.toString(), "db", "ORACLE");
+                tempDir.toString(), "mi-connector-db", "ORACLE");
 
         assertNotNull(result);
         assertEquals(Boolean.TRUE, result.omit);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This improvement introduces a connector-config.json to store connector dependency overrides in the project level.  This PR also unifies the DB connector with this approach.

Sample connector-config.json
```
{
  "version" : "1.0",
  "connectors" : {
    "mi-connector-db" : {
      "qname" : "{org.wso2.carbon.esb.connector}db",
      "dependencies" : [ {
        "connectionType" : "MICROSOFT_SQL_SERVER",
        "groupId" : "com.microsoft.sqlserver",
        "artifactId" : "mssql-jdbc",
        "version" : "13.4.0.jre11"
      }, {
        "connectionType" : "MYSQL",
        "groupId" : "com.mysql",
        "artifactId" : "mysql-connector-j",
        "version" : "",
        "localPath" : "/Users/wso2/mysql-connector-j-8.0.1.jar"
      } ]
    }
  }
}
```