### PR TITLE
[4.0.0] Improve Dependent Integration Project Connector Loading

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -1024,12 +1024,12 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     public CompletableFuture<LoadDependentResourcesResponse> loadDependentResources() {
 
         return CompletableFuture.supplyAsync(() -> {
-			log.info("Loading dependent resources for project: " + projectUri);
-			LoadDependentResourcesResponse result = resourceFinder.loadDependentResources(projectUri);
-        	updateConnectors();
-			log.fine("Dependent resources loaded successfully for project: " + projectUri);
-			return result;
-		});
+            log.info("Loading dependent resources for project: " + projectUri);
+            LoadDependentResourcesResponse result = resourceFinder.loadDependentResources(projectUri);
+            updateConnectors();
+            log.info("Dependent resources loaded successfully for project: " + projectUri);
+            return result;
+        });
     }
 
     @Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -1024,8 +1024,10 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     public CompletableFuture<LoadDependentResourcesResponse> loadDependentResources() {
 
         return CompletableFuture.supplyAsync(() -> {
+			log.info("Loading dependent resources for project: " + projectUri);
 			LoadDependentResourcesResponse result = resourceFinder.loadDependentResources(projectUri);
         	updateConnectors();
+			log.fine("Dependent resources loaded successfully for project: " + projectUri);
 			return result;
 		});
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
@@ -202,6 +202,7 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
 
         Path extractedDir = findProjectDependencyExtractedDir();
         if (extractedDir == null) {
+            log.info("No dependency project extracted directory found for project: " + projectId);
             return;
         }
         File[] dependentProjects = extractedDir.toFile().listFiles(File::isDirectory);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/connectors/NewProjectConnectorLoader.java
@@ -205,10 +205,13 @@ public class NewProjectConnectorLoader extends AbstractConnectorLoader {
             log.info("No dependency project extracted directory found for project: " + projectId);
             return;
         }
+		log.info("Found dependency project extracted directory: " + extractedDir + " for project: " + projectId);
         File[] dependentProjects = extractedDir.toFile().listFiles(File::isDirectory);
         if (dependentProjects == null) {
+			log.info("No dependent projects found in extracted directory: " + extractedDir);
             return;
         }
+		log.info("Found " + dependentProjects.length + " dependent projects in: " + extractedDir);
         for (File dependentProject : dependentProjects) {
             Path connectorPath = dependentProject.toPath()
                     .resolve(Constant.SRC).resolve(Constant.MAIN).resolve(Constant.WSO2MI)

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
@@ -18,6 +18,7 @@ import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 import org.eclipse.lemminx.customservice.synapse.utils.Utils;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -96,9 +97,15 @@ public class DependencyDownloadManager {
         Node isVersionedDeployment = pomDetailsResponse.getBuildDetails().getVersionedDeployment();
         boolean isVersionedDeploymentEnabled = isVersionedDeployment != null ?
                 Boolean.parseBoolean(isVersionedDeployment.getValue()) : false;
-        IntegrationProjectDependencyDownloadResult result =
-                IntegrationProjectDownloadManager.refetchDependencies(projectPath, integrationProjectDependencies,
-                        isVersionedDeploymentEnabled);
+        IntegrationProjectDependencyDownloadResult result;
+        try {
+            result = IntegrationProjectDownloadManager.refetchDependencies(projectPath, integrationProjectDependencies,
+                    isVersionedDeploymentEnabled);
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "Failed to clear dependency directories for project " + projectPath
+                    + ": " + e.getMessage());
+            return "Failed to clear dependency directories: " + e.getMessage();
+        }
 
         String errorMessage = buildIntegrationProjectsErrorMessage(result);
         if (errorMessage.isEmpty()) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/DependencyDownloadManager.java
@@ -89,7 +89,6 @@ public class DependencyDownloadManager {
      */
     public static String refetchIntegrationProjectDependencies(String projectPath) {
 
-        LOGGER.log(Level.INFO, "Starting integration project dependencies re-fetch for project: " + projectPath);
         OverviewPageDetailsResponse pomDetailsResponse = new OverviewPageDetailsResponse();
         getPomDetails(projectPath, pomDetailsResponse);
         List<DependencyDetails> integrationProjectDependencies =
@@ -97,6 +96,9 @@ public class DependencyDownloadManager {
         Node isVersionedDeployment = pomDetailsResponse.getBuildDetails().getVersionedDeployment();
         boolean isVersionedDeploymentEnabled = isVersionedDeployment != null ?
                 Boolean.parseBoolean(isVersionedDeployment.getValue()) : false;
+        LOGGER.log(Level.INFO, "Starting integration project dependencies re-fetch for project: " + projectPath
+                + ", versioned deployment: " + isVersionedDeploymentEnabled);
+        
         IntegrationProjectDependencyDownloadResult result;
         try {
             result = IntegrationProjectDownloadManager.refetchDependencies(projectPath, integrationProjectDependencies,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDependencyDownloadResult.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDependencyDownloadResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -73,7 +73,7 @@ public class IntegrationProjectDownloadManager {
      * @return a result object containing any dependencies that failed to download or process
      */
     public static IntegrationProjectDependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
-                                                               boolean isVersionedDeploymentEnabled) {
+                                                               boolean isVersionedDeploymentEnabled) throws IOException {
 
         LOGGER.log(Level.INFO, "Starting hard refresh of dependencies for project: " + new File(projectPath).getName()
                 + " with " + dependencies.size() + " dependencies");
@@ -82,7 +82,7 @@ public class IntegrationProjectDownloadManager {
     }
 
     public static IntegrationProjectDependencyDownloadResult refetchDependencies(String projectPath, List<DependencyDetails> dependencies,
-                                                        boolean isVersionedDeploymentEnabled, Path userHome) {
+                                                        boolean isVersionedDeploymentEnabled, Path userHome) throws IOException {
 
         String projectId = new File(projectPath).getName() + UNDERSCORE + Utils.getHash(projectPath);
         File directory = userHome.resolve(Constant.WSO2_MI)
@@ -103,6 +103,7 @@ public class IntegrationProjectDownloadManager {
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Failed to clear dependency directories for project " + projectId
                     + ": " + e.getMessage());
+            throw e;
         }
 
         return downloadDependencies(projectPath, dependencies, isVersionedDeploymentEnabled, userHome);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -101,7 +101,7 @@ public class IntegrationProjectDownloadManager {
                 LOGGER.log(Level.INFO, "Cleared Extracted directory for project: " + projectId);
             }
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to clear dependency directories for project " + projectId
+            LOGGER.log(Level.SEVERE, "Failed to clear dependency directories for project " + projectId
                     + ": " + e.getMessage());
         }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/parser/IntegrationProjectDownloadManager.java
@@ -152,13 +152,14 @@ public class IntegrationProjectDownloadManager {
         List<String> failedDependencies = new ArrayList<>();
         List<String> noDescriptorDependencies = new ArrayList<>();
         List<String> versioningMismatchDependencies = new ArrayList<>();
-        Set<String> fetchedDependencies = new HashSet<>();
+        Set<String> visitedDependencies = new HashSet<>();
+        Set<String> resolvedDependencies = new HashSet<>();
 
         for (DependencyDetails dependency : dependencies) {
             try {
                 LOGGER.log(Level.INFO, "Processing dependency: " + dependency.getGroupId() + HYPHEN
                         + dependency.getArtifact() + HYPHEN + dependency.getVersion());
-                fetchDependencyRecursively(dependency, downloadDirectory, fetchedDependencies,
+                fetchDependencyRecursively(dependency, downloadDirectory, visitedDependencies, resolvedDependencies,
                         isVersionedDeploymentEnabled, userHome);
             } catch (NoDescriptorException e) {
                 String failedDependency =
@@ -182,7 +183,7 @@ public class IntegrationProjectDownloadManager {
             }
         }
 
-        Set<String> expectedBaseNames = buildExpectedBaseNames(fetchedDependencies);
+        Set<String> expectedBaseNames = buildExpectedBaseNames(resolvedDependencies);
         deleteObsoleteDownloadedFiles(downloadDirectory, expectedBaseNames);
         deleteObsoleteExtractedDirs(extractDirectory, expectedBaseNames);
 
@@ -273,24 +274,25 @@ public class IntegrationProjectDownloadManager {
      * downloads and infinite loops.
      * </p>
      *
-     * @param dependency          the dependency to fetch
-     * @param downloadDirectory   the directory to store downloaded .car files
-     * @param fetchedDependencies a set of dependency keys already fetched to prevent duplication
+     * @param dependency           the dependency to fetch
+     * @param downloadDirectory    the directory to store downloaded .car files
+     * @param visitedDependencies  a set of dependency keys already visited to prevent duplicate processing and infinite loops
+     * @param resolvedDependencies a set of dependency keys successfully fetched and parsed, used to determine which cached files to keep
      * @param isVersionedDeploymentEnabled indicates if versioned deployment is enabled in the parent project
      * @throws Exception if fetching or parsing fails
      */
     static void fetchDependencyRecursively(DependencyDetails dependency, File downloadDirectory,
-                                           Set<String> fetchedDependencies, boolean isVersionedDeploymentEnabled,
-                                           Path userHome)
+                                           Set<String> visitedDependencies, Set<String> resolvedDependencies,
+                                           boolean isVersionedDeploymentEnabled, Path userHome)
             throws Exception {
 
         // Colon separator avoids key collisions as colons are invalid in Maven coordinates.
         String dependencyKey = dependency.getGroupId() + COLON + dependency.getArtifact() + COLON + dependency.getVersion();
-        if (fetchedDependencies.contains(dependencyKey)) {
-            return; // Skip already fetched dependencies
+        if (visitedDependencies.contains(dependencyKey)) {
+            return; // Skip already visited dependencies
         }
 
-        fetchedDependencies.add(dependencyKey);
+        visitedDependencies.add(dependencyKey);
 
         String carBaseName = dependency.getGroupId() + HYPHEN + dependency.getArtifact() + HYPHEN + dependency.getVersion();
 
@@ -317,10 +319,12 @@ public class IntegrationProjectDownloadManager {
             throw e;
         }
 
+        resolvedDependencies.add(dependencyKey);
+
         // Recursively fetch transitive dependencies
         for (DependencyDetails transitiveDependency : transitiveDependencies) {
             fetchDependencyRecursively(transitiveDependency, downloadDirectory,
-                    fetchedDependencies, isVersionedDeploymentEnabled, userHome);
+                    visitedDependencies, resolvedDependencies, isVersionedDeploymentEnabled, userHome);
         }
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
@@ -88,11 +88,10 @@ public abstract class AbstractResourceFinder {
     private static final String CONNECTOR_REGISTRY_KEY_PREFIX = "resources:connectors/";
 
     /**
-     * Name prefix of the built-in HTTP connector. The HTTP connector is bundled with every
-     * project, so any connector whose name starts with this prefix is excluded from dependency
-     * conflict detection.
+     * Core name (version-stripped) of the built-in HTTP connector. The HTTP connector is bundled
+     * with every project and is excluded from dependency conflict detection.
      */
-    private static final String HTTP_CONNECTOR_PREFIX = "mi-connector-http";
+    private static final String HTTP_CONNECTOR_CORE_NAME = "mi-connector-http";
     protected static final List<String> resourceFromRegistryOnly = List.of("dataMapper", "js", "json", "smooksConfig",
             "wsdl", "ws_policy", "xsd", "xsl", "xslt", "yaml", "registry", "unitTestRegistry", "schema", "swagger");
 
@@ -211,8 +210,8 @@ public abstract class AbstractResourceFinder {
                     mergeDepResources(depResources);
                     existingResourceNames.addAll(depResourceNames);
                     depConnectorZipBaseNames.stream()
-                            .filter(n -> !n.startsWith(HTTP_CONNECTOR_PREFIX))
                             .map(Utils::stripConnectorVersion)
+                            .filter(n -> !HTTP_CONNECTOR_CORE_NAME.equals(n))
                             .forEach(loadedDepConnectorCoreNames::add);
                 }
             }
@@ -360,7 +359,7 @@ public abstract class AbstractResourceFinder {
      * {@code mi-connector-email-2.0.1} are treated as the same connector because loading two
      * different versions of a connector simultaneously is not supported.
      * <p>
-     * The built-in HTTP connector ({@value #HTTP_CONNECTOR_PREFIX}) is always excluded from
+     * The built-in HTTP connector ({@value #HTTP_CONNECTOR_CORE_NAME}) is always excluded from
      * conflict detection because it is bundled with every project.
      *
      * @param depConnectorZipBaseNames        zip base names (without {@code .zip}) from the dependency
@@ -378,10 +377,10 @@ public abstract class AbstractResourceFinder {
 
         Set<String> conflicting = new HashSet<>();
         for (String zipBaseName : depConnectorZipBaseNames) {
-            if (zipBaseName.startsWith(HTTP_CONNECTOR_PREFIX)) {
+            String coreName = Utils.stripConnectorVersion(zipBaseName);
+            if (HTTP_CONNECTOR_CORE_NAME.equals(coreName)) {
                 continue;
             }
-            String coreName = Utils.stripConnectorVersion(zipBaseName);
             boolean conflictsWithHolder = existingConnectorArtifactIds.contains(coreName);
             boolean conflictsWithCurrentRun = loadedDepConnectorCoreNames.contains(coreName);
             if (conflictsWithHolder || conflictsWithCurrentRun) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/resourceFinder/AbstractResourceFinder.java
@@ -379,6 +379,7 @@ public abstract class AbstractResourceFinder {
         for (String zipBaseName : depConnectorZipBaseNames) {
             String coreName = Utils.stripConnectorVersion(zipBaseName);
             if (HTTP_CONNECTOR_CORE_NAME.equals(coreName)) {
+				LOGGER.info("Skipping conflict check for built-in HTTP connector: " + zipBaseName);
                 continue;
             }
             boolean conflictsWithHolder = existingConnectorArtifactIds.contains(coreName);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -551,6 +551,7 @@ public class Utils {
      */
     public static String stripConnectorVersion(String zipBaseName) {
 
+        logger.log(Level.INFO, "Stripping version from connector zip base name: {}", zipBaseName);
         int lastHyphen = zipBaseName.lastIndexOf(Constant.HYPHEN);
         return lastHyphen > 0 ? zipBaseName.substring(0, lastHyphen) : zipBaseName;
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -551,7 +551,7 @@ public class Utils {
      */
     public static String stripConnectorVersion(String zipBaseName) {
 
-        logger.log(Level.INFO, "Stripping version from connector zip base name: {}", zipBaseName);
+        logger.info("Stripping version from connector zip base name: " + zipBaseName);
         int lastHyphen = zipBaseName.lastIndexOf(Constant.HYPHEN);
         return lastHyphen > 0 ? zipBaseName.substring(0, lastHyphen) : zipBaseName;
     }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/TestUtils.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/TestUtils.java
@@ -21,9 +21,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TestUtils {
 
@@ -43,6 +48,19 @@ public class TestUtils {
             String zipName = zip.getName();
             zipName = zipName.substring(0, zipName.lastIndexOf(Constant.DOT));
             Utils.extractZip(zip, extractFolder.resolve(zipName).toFile());
+        }
+    }
+
+    public static void deleteRecursively(Path path) throws IOException {
+
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(path)) {
+            List<Path> sorted = paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+            for (Path p : sorted) {
+                Files.deleteIfExists(p);
+            }
         }
     }
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/downloader/ConnectorDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/downloader/ConnectorDownloadManagerTest.java
@@ -90,8 +90,9 @@ public class ConnectorDownloadManagerTest {
 
         ConnectorDependencyDownloadResult result = ConnectorDownloadManager.downloadDependencies(projectPath, connectorDependencies);
 
+        assertEquals(0, result.getFailedDependencies().size());
         assertTrue(result.getFromIntegrationProjectDependencies().stream().anyMatch(dep -> dep.contains("mi-connector-http")),
-                "Connector from integration project dependency should be marked as failed");
+                "Connector from integration project dependency should be in fromIntegrationProjectDependencies list");
     }
 
     @Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
@@ -31,10 +31,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Logger;
 
+import static org.eclipse.lemminx.synapse.TestUtils.deleteRecursively;
 import static org.eclipse.lemminx.synapse.TestUtils.getResourceFilePath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -109,6 +109,7 @@ public class NewDependentProjectConnectorLoaderTest {
     public void tearDown() throws IOException {
 
         LOGGER.info("Tearing down test environment for NewDependentProjectConnectorLoaderTest");
+        ConnectorHolder.getInstance().clearConnectors();
         deleteRecursively(tempHome);
         deleteRecursively(projectRoot);
     }
@@ -365,7 +366,10 @@ public class NewDependentProjectConnectorLoaderTest {
         loader.init(projectRoot.toString());
         loader.loadConnector();
 
-        Connector connector = ConnectorHolder.getInstance().getConnector("http");
+        ConnectorHolder holder = ConnectorHolder.getInstance();
+        assertEquals(1, holder.getConnectors().size(),
+                "Same connector in project and dependency should be loaded only once");
+        Connector connector = holder.getConnector("http");
         assertNotNull(connector, "http connector should be loaded");
         assertTrue(connector.isFromProject(),
                 "Connector present in both project and dependency should be marked as fromProject");
@@ -494,16 +498,4 @@ public class NewDependentProjectConnectorLoaderTest {
         return extractedDir;
     }
 
-    private static void deleteRecursively(Path path) throws IOException {
-
-        if (path == null || !Files.exists(path)) {
-            LOGGER.info("Skipping deletion - path is null or does not exist");
-            return;
-        }
-        LOGGER.info("Deleting directory recursively: " + path.toString());
-        Files.walk(path)
-                .sorted(Comparator.reverseOrder())
-                .map(Path::toFile)
-                .forEach(File::delete);
-    }
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/connector/loader/NewDependentProjectConnectorLoaderTest.java
@@ -497,8 +497,10 @@ public class NewDependentProjectConnectorLoaderTest {
     private static void deleteRecursively(Path path) throws IOException {
 
         if (path == null || !Files.exists(path)) {
+            LOGGER.info("Skipping deletion - path is null or does not exist");
             return;
         }
+        LOGGER.info("Deleting directory recursively: " + path.toString());
         Files.walk(path)
                 .sorted(Comparator.reverseOrder())
                 .map(Path::toFile)

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/parser/IntegrationProjectDownloadManagerTest.java
@@ -19,6 +19,7 @@ import org.eclipse.lemminx.customservice.synapse.parser.IntegrationProjectDepend
 import org.eclipse.lemminx.customservice.synapse.parser.IntegrationProjectDownloadManager;
 import org.eclipse.lemminx.customservice.synapse.utils.Constant;
 import org.eclipse.lemminx.customservice.synapse.utils.Utils;
+import org.eclipse.lemminx.synapse.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -69,8 +69,8 @@ public class IntegrationProjectDownloadManagerTest {
     @AfterEach
     public void tearDown() throws IOException {
 
-        deleteRecursively(tempHome);
-        deleteRecursively(projectRoot);
+        TestUtils.deleteRecursively(tempHome);
+        TestUtils.deleteRecursively(projectRoot);
     }
 
     // -------------------------------------------------------------------------
@@ -112,7 +112,7 @@ public class IntegrationProjectDownloadManagerTest {
         DependencyDetails dep = makeDep("com.example", "my-project", "1.0.0", "car");
 
         try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
-            utilsMock.when(() -> Utils.getDependencyFromLocalRepo(any(), any(), any(), any()))
+            utilsMock.when(() -> Utils.getDependencyFromLocalRepo(any(), any(), any(), any(), any()))
                     .thenReturn(null);
             utilsMock.when(() -> Utils.getHash(any())).thenCallRealMethod();
             utilsMock.when(() -> Utils.deleteDirectory(any())).thenCallRealMethod();
@@ -1021,14 +1021,4 @@ public class IntegrationProjectDownloadManagerTest {
         assertTrue(result.getVersioningTypeMismatchDependencies().isEmpty());
     }
 
-    private static void deleteRecursively(Path path) throws IOException {
-
-        if (path == null || !Files.exists(path)) {
-            return;
-        }
-        Files.walk(path)
-                .sorted(Comparator.reverseOrder())
-                .map(Path::toFile)
-                .forEach(File::delete);
-    }
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/resource/finder/LoadDependentResourcesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/resource/finder/LoadDependentResourcesTest.java
@@ -462,8 +462,9 @@ public class LoadDependentResourcesTest {
     void testConflictBetweenDependentProjectsDetected() throws IOException {
 
         Path depBaseDir = createDependencyBaseDir();
-        // dep1 is created first so its directory has an older mtime and is processed first
+        // dep1 is created first and back-dated so its mtime is deterministically older than dep2's
         Path dep1 = createDependentProject(depBaseDir, "adep1", "com.example", "dep1", "1.0.0");
+        Files.setLastModifiedTime(dep1, FileTime.fromMillis(System.currentTimeMillis() - 5000));
         Path dep2 = createDependentProject(depBaseDir, "bdep2", "com.example", "dep2", "2.0.0");
 
         resourceFinder.setProjectResources(mainProjectPath, new HashMap<>());
@@ -486,6 +487,7 @@ public class LoadDependentResourcesTest {
 
         Path depBaseDir = createDependencyBaseDir();
         Path dep1 = createDependentProject(depBaseDir, "adep1", "com.example", "dep1", "1.0.0");
+        Files.setLastModifiedTime(dep1, FileTime.fromMillis(System.currentTimeMillis() - 5000));
         Path dep2 = createDependentProject(depBaseDir, "bdep2", "com.example", "dep2", "2.0.0");
 
         resourceFinder.setProjectResources(mainProjectPath, new HashMap<>());
@@ -743,6 +745,7 @@ public class LoadDependentResourcesTest {
         // ConnectorHolder is empty — both deps are new
         Path depBaseDir = createDependencyBaseDir();
         Path dep1 = createDependentProject(depBaseDir, "adep1", "com.example", "dep1", "1.0.0");
+        Files.setLastModifiedTime(dep1, FileTime.fromMillis(System.currentTimeMillis() - 5000));
         Path dep2 = createDependentProject(depBaseDir, "bdep2", "com.example", "dep2", "2.0.0");
 
         resourceFinder.setProjectResources(mainProjectPath, new HashMap<>());
@@ -767,6 +770,7 @@ public class LoadDependentResourcesTest {
 
         Path depBaseDir = createDependencyBaseDir();
         Path dep1 = createDependentProject(depBaseDir, "adep1", "com.example", "dep1", "1.0.0");
+        Files.setLastModifiedTime(dep1, FileTime.fromMillis(System.currentTimeMillis() - 5000));
         Path dep2 = createDependentProject(depBaseDir, "bdep2", "com.example", "dep2", "2.0.0");
 
         resourceFinder.setProjectResources(mainProjectPath, new HashMap<>());
@@ -1143,6 +1147,7 @@ public class LoadDependentResourcesTest {
         // dep1 has salesforce 1.0.0, dep2 has salesforce 2.0.0 — different versions, same connector
         Path depBaseDir = createDependencyBaseDir();
         Path dep1 = createDependentProject(depBaseDir, "adep1", "com.example", "dep1", "1.0.0");
+        Files.setLastModifiedTime(dep1, FileTime.fromMillis(System.currentTimeMillis() - 5000));
         Path dep2 = createDependentProject(depBaseDir, "bdep2", "com.example", "dep2", "2.0.0");
 
         resourceFinder.setProjectResources(mainProjectPath, new HashMap<>());
@@ -1308,6 +1313,7 @@ public class LoadDependentResourcesTest {
 
         Path depBaseDir = createDependencyBaseDir();
         Path dep1 = createDependentProject(depBaseDir, "adep1", "com.example", "dep1", "1.0.0");
+        Files.setLastModifiedTime(dep1, FileTime.fromMillis(System.currentTimeMillis() - 5000));
         Path dep2 = createDependentProject(depBaseDir, "bdep2", "com.example", "dep2", "2.0.0");
 
         resourceFinder.setProjectResources(mainProjectPath, new HashMap<>());


### PR DESCRIPTION
## Purpose
Introduce the following changes
- Fail refetch if cached dependent files' directories cannot be deleted before fresh download.
- Maintain visited and resolved dependencies separately, making only resolved dependencies available at the end in Downloaded/Extracted dirs.
- Use exact HTTP connector name for conflict detection instead of prefix matching.

Porting new changes from https://github.com/wso2/mi-language-server/pull/529 