### PR TITLE
Improve Synapse expression and cross-file diagnostics for MI Copilot

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -150,6 +150,7 @@ import org.eclipse.lemminx.customservice.synapse.utils.Utils;
 import org.eclipse.lemminx.customservice.synapse.idp.PdfToImagesRequest;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
+import org.eclipse.lemminx.extensions.synapse.SynapseDiagnosticsParticipant;
 import org.eclipse.lemminx.services.extensions.completion.ICompletionResponse;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.uriresolver.URIResolverExtensionManager;
@@ -349,9 +350,18 @@ public class SynapseLanguageService implements ISynapseLanguageService {
             // Use the real file path (when supplied) as the document URI. Several diagnostics are
             // gated on the document path — e.g. SynapseExpressionValidator only runs for files under
             // src/main/wso2mi/artifacts — so the literal "temp" fallback would silently drop them.
-            String uri = param.getFileName() != null ? param.getFileName() : "temp";
-            DOMDocument xmlDocument = Utils.getDOMDocument(param.getCode(), uri, uriResolverExtensionManager);
-            return doDiagnostics(xmlDocument, NULL_CANCEL_CHECKER);
+            // Treat a blank fileName as missing, otherwise an unusable URI would skip those checks.
+            String uri = StringUtils.isBlank(param.getFileName()) ? "temp" : param.getFileName();
+            // Opt-out (default off) for cross-file reference checks: the agent validates a file
+            // before its referenced siblings are written, so those checks would fire spuriously.
+            // Set/clear around doDiagnostics on this thread; the editor never sets it.
+            try {
+                SynapseDiagnosticsParticipant.setSkipCrossFileValidation(param.isSkipCrossFileValidation());
+                DOMDocument xmlDocument = Utils.getDOMDocument(param.getCode(), uri, uriResolverExtensionManager);
+                return doDiagnostics(xmlDocument, NULL_CANCEL_CHECKER);
+            } finally {
+                SynapseDiagnosticsParticipant.clearSkipCrossFileValidation();
+            }
         });
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/SynapseLanguageService.java
@@ -346,7 +346,11 @@ public class SynapseLanguageService implements ISynapseLanguageService {
     public CompletableFuture<PublishDiagnosticsParams> codeDiagnostic(CodeDiagnosticRequest param) {
 
         return CompletableFuture.supplyAsync(() -> {
-            DOMDocument xmlDocument = Utils.getDOMDocument(param.getCode(), uriResolverExtensionManager);
+            // Use the real file path (when supplied) as the document URI. Several diagnostics are
+            // gated on the document path — e.g. SynapseExpressionValidator only runs for files under
+            // src/main/wso2mi/artifacts — so the literal "temp" fallback would silently drop them.
+            String uri = param.getFileName() != null ? param.getFileName() : "temp";
+            DOMDocument xmlDocument = Utils.getDOMDocument(param.getCode(), uri, uriResolverExtensionManager);
             return doDiagnostics(xmlDocument, NULL_CANCEL_CHECKER);
         });
     }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -39,6 +39,7 @@ import org.eclipse.lemminx.commons.TextDocument;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMParser;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationRootSettings;
+import org.eclipse.lemminx.extensions.synapse.SynapseDiagnosticsParticipant;
 import org.eclipse.lemminx.services.DocumentSymbolsResult;
 import org.eclipse.lemminx.services.SymbolInformationResult;
 import org.eclipse.lemminx.services.XMLLanguageService;
@@ -599,7 +600,13 @@ public class XMLTextDocumentService implements TextDocumentService {
 	public void didSave(DidSaveTextDocumentParams params) {
 		computeAsync((monitor) -> {
 			// A document was saved, collect documents to revalidate
-			SaveContext context = new SaveContext(params.getTextDocument().getUri());
+			String savedUri = params.getTextDocument().getUri();
+			if (savedUri != null && savedUri.contains("src/main/wso2mi")) {
+				// An artifact/resource file was saved — drop the cached cross-file index so the
+				// revalidation below (and sibling files) sees the updated set instead of stale data.
+				SynapseDiagnosticsParticipant.invalidateArtifactIndexCache();
+			}
+			SaveContext context = new SaveContext(savedUri);
 			doSave(context);
 
 			// Manage didSave document lifecycle participants

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLWorkspaceService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLWorkspaceService.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lemminx.commons.WorkspaceFolders;
 import org.eclipse.lemminx.customservice.synapse.utils.Constant;
+import org.eclipse.lemminx.extensions.synapse.SynapseDiagnosticsParticipant;
 import org.eclipse.lemminx.services.extensions.commands.IXMLCommandService;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
@@ -99,6 +100,12 @@ public class XMLWorkspaceService implements WorkspaceService, IXMLCommandService
 			} else if (change.getUri().contains(Constant.CONNECTORS) && change.getUri().contains(".zip")) {
 				((SynapseLanguageService) xmlLanguageServer.getSynapseLanguageService()).updateConnectors();
 			} else {
+				if (change.getUri().contains("src/main/wso2mi")) {
+					// An artifact/resource file changed on disk — drop the cached cross-file index so
+					// the next diagnostics run rebuilds it (otherwise a just-written sibling stays
+					// "unresolved" for up to the cache TTL).
+					SynapseDiagnosticsParticipant.invalidateArtifactIndexCache();
+				}
 				if (!xmlTextDocumentService.documentIsOpen(change.getUri())) {
 					xmlTextDocumentService.doSave(change.getUri());
 				}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/CodeDiagnosticRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/CodeDiagnosticRequest.java
@@ -18,6 +18,7 @@ public class CodeDiagnosticRequest {
 
     private String code;
     private String fileName;
+    private boolean skipCrossFileValidation;
 
     public String getCode() {
 
@@ -37,5 +38,21 @@ public class CodeDiagnosticRequest {
     public void setFileName(String fileName) {
 
         this.fileName = fileName;
+    }
+
+    /**
+     * When true, cross-file reference checks (which depend on other artifact files existing) are
+     * skipped for this request. Defaults to false, so the editor and the explicit "validate all"
+     * path are unaffected. The MI Copilot agent sets it for per-file auto-validation after a write,
+     * where a referenced sibling artifact may not exist on disk yet.
+     */
+    public boolean isSkipCrossFileValidation() {
+
+        return skipCrossFileValidation;
+    }
+
+    public void setSkipCrossFileValidation(boolean skipCrossFileValidation) {
+
+        this.skipCrossFileValidation = skipCrossFileValidation;
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/CodeDiagnosticRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/CodeDiagnosticRequest.java
@@ -17,6 +17,7 @@ package org.eclipse.lemminx.customservice.synapse;
 public class CodeDiagnosticRequest {
 
     private String code;
+    private String fileName;
 
     public String getCode() {
 
@@ -26,5 +27,15 @@ public class CodeDiagnosticRequest {
     public void setCode(String code) {
 
         this.code = code;
+    }
+
+    public String getFileName() {
+
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+
+        this.fileName = fileName;
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/expression/SemanticExpressionValidator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/expression/SemanticExpressionValidator.java
@@ -198,6 +198,64 @@ public class SemanticExpressionValidator extends ExpressionParserBaseVisitor<Voi
         return true;
     }
 
+    /**
+     * Detects the operator-precedence pitfall where a logical operator ('and'/'or') is used as a
+     * direct, unparenthesized operand of a comparison operator. In the Synapse expression grammar,
+     * 'and'/'or' bind TIGHTER than the comparison operators (&lt;, &gt;, &lt;=, &gt;=, ==, !=), so an
+     * expression such as {@code a <= 0 or b > 10} parses as {@code a <= (0 or b) > 10} instead of
+     * the usually-intended {@code (a <= 0) or (b > 10)}. A warning is emitted recommending explicit
+     * parentheses. The correctly-parenthesized form parses as a single top-level logical expression
+     * with no comparison operator at this node, so it is never flagged (no false positives).
+     */
+    @Override
+    public Void visitComparisonExpression(ExpressionParser.ComparisonExpressionContext ctx) {
+        if (hasComparisonOperator(ctx)) {
+            for (ExpressionParser.LogicalExpressionContext operand : ctx.logicalExpression()) {
+                TerminalNode logicalOp = operand.AND() != null ? operand.AND() : operand.OR();
+                if (logicalOp != null) {
+                    Token opToken = logicalOp.getSymbol();
+                    String op = opToken.getText();
+                    String message = "Operator precedence: '" + op + "' binds tighter than the comparison "
+                            + "operators (<, >, <=, >=, ==, !=) in Synapse expressions, so '" + op
+                            + "' is evaluated before the comparison. This is likely not the intended "
+                            + "behavior. Add parentheses around each comparison to make the intent "
+                            + "explicit, e.g. (a <= 0) " + op + " (b > 10).";
+                    ExpressionError error = new ExpressionError(opToken.getLine(),
+                            opToken.getCharPositionInLine(), message, opToken, null);
+                    error.setWarning(true);
+                    errors.add(error);
+                    break; // One warning per comparison expression is sufficient.
+                }
+            }
+        }
+        return visitChildren(ctx);
+    }
+
+    /**
+     * Returns true if this comparison expression actually applies a comparison operator, as opposed
+     * to being a pass-through to a single logical expression. Checks the direct children for a
+     * comparison operator token rather than relying on a specific generated accessor.
+     */
+    private boolean hasComparisonOperator(ExpressionParser.ComparisonExpressionContext ctx) {
+        for (int i = 0; i < ctx.getChildCount(); i++) {
+            if (ctx.getChild(i) instanceof TerminalNode) {
+                int type = ((TerminalNode) ctx.getChild(i)).getSymbol().getType();
+                switch (type) {
+                    case ExpressionLexer.GT:
+                    case ExpressionLexer.LT:
+                    case ExpressionLexer.GTE:
+                    case ExpressionLexer.LTE:
+                    case ExpressionLexer.EQ:
+                    case ExpressionLexer.NEQ:
+                        return true;
+                    default:
+                        break;
+                }
+            }
+        }
+        return false;
+    }
+
     @Override
     public Void visitArithmeticExpression(ExpressionParser.ArithmeticExpressionContext ctx) {
         List<ExpressionParser.TermContext> terms = ctx.term();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/utils/Utils.java
@@ -270,7 +270,24 @@ public class Utils {
 
     public static DOMDocument getDOMDocument(String content, URIResolverExtensionManager resolverExtensionManager) {
 
-        TextDocument document = new TextDocument(content, "temp");
+        return getDOMDocument(content, "temp", resolverExtensionManager);
+    }
+
+    /**
+     * Get the DOM document from the given xml content, using the provided URI as the document's
+     * system id. The URI matters for diagnostics that are gated on the document path (e.g.
+     * SynapseExpressionValidator only runs for files under src/main/wso2mi/artifacts), so callers
+     * that have a real file path should pass it instead of relying on the "temp" fallback.
+     *
+     * @param content                  the xml content
+     * @param uri                      the URI to assign to the parsed document
+     * @param resolverExtensionManager the URI resolver extension manager
+     * @return the DOM document for the given xml content
+     */
+    public static DOMDocument getDOMDocument(String content, String uri,
+                                             URIResolverExtensionManager resolverExtensionManager) {
+
+        TextDocument document = new TextDocument(content, uri);
         return DOMParser.getInstance().parse(document, resolverExtensionManager);
     }
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipant.java
@@ -236,6 +236,10 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
         // Validate variable references in expression attributes
         validateVariableReferences(element, diagnostics, document, definedVariables);
 
+        // Flag an opening "${" with no matching "}" (the malformed expression is otherwise
+        // treated as a plain string and reaches runtime with no feedback)
+        validateUnclosedExpressions(element, diagnostics, document);
+
         // Cross-file reference validation
         if (knownArtifacts != null) {
             validateCrossReferences(element, diagnostics, knownArtifacts);
@@ -1248,6 +1252,103 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
                 }
             }
         }
+    }
+
+    /**
+     * Flags an opening "${" that is never closed by a matching "}". Such a value is not recognized
+     * as a Synapse expression (it is treated as a plain string), so the malformed expression would
+     * otherwise reach runtime with no feedback. Scans attribute values and leaf element text,
+     * mirroring the variable-reference checks; raw-code elements (see {@link #RAW_TEXT_ELEMENTS})
+     * are skipped to avoid false positives.
+     */
+    private void validateUnclosedExpressions(DOMElement element, List<Diagnostic> diagnostics,
+                                             DOMDocument document) {
+        List<DOMAttr> attrs = element.getAttributeNodes();
+        if (attrs != null) {
+            for (DOMAttr attr : attrs) {
+                String attrValue = attr.getValue();
+                if (attrValue != null && attrValue.contains("${") && hasUnclosedExpression(attrValue)) {
+                    reportUnclosedExpression(XMLPositionUtility.selectAttributeValue(attr), diagnostics);
+                }
+            }
+        }
+
+        if (hasChildElements(element)) {
+            return;
+        }
+        String localName = element.getLocalName();
+        if (localName != null && RAW_TEXT_ELEMENTS.contains(localName.toLowerCase())) {
+            return;
+        }
+        List<DOMNode> children = element.getChildren();
+        if (children == null) {
+            return;
+        }
+        for (DOMNode child : children) {
+            if (!child.isText()) {
+                continue;
+            }
+            String text = child.getTextContent();
+            if (text != null && text.contains("${") && hasUnclosedExpression(text)) {
+                reportUnclosedExpression(
+                        XMLPositionUtility.createRange(child.getStart(), child.getEnd(), document), diagnostics);
+            }
+        }
+    }
+
+    private void reportUnclosedExpression(Range range, List<Diagnostic> diagnostics) {
+        if (range == null) {
+            return;
+        }
+        Diagnostic d = new Diagnostic();
+        d.setRange(range);
+        d.setMessage("Unclosed expression: '${' is not terminated by a matching '}'. " +
+                "Synapse expressions must be written as ${...} — add the missing '}'.");
+        d.setSeverity(DiagnosticSeverity.Warning);
+        d.setSource(SOURCE);
+        d.setCode("UnclosedExpression");
+        diagnostics.add(d);
+    }
+
+    /**
+     * Returns true if {@code value} contains an opening "${" with no matching "}" closing it.
+     * Synapse expressions have no "{"/"}" tokens of their own (indexing uses "[" "]"), so the only
+     * braces that can appear inside ${...} are within string literals — which are skipped here, so a
+     * valid expression such as {@code ${concat('{', x)}} is not mistaken for unclosed.
+     */
+    private boolean hasUnclosedExpression(String value) {
+        int open = value.indexOf("${");
+        while (open >= 0) {
+            if (!hasClosingBrace(value, open + 2)) {
+                return true;
+            }
+            open = value.indexOf("${", open + 2);
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if there is a '}' at or after {@code from} that lies outside any string literal.
+     */
+    private boolean hasClosingBrace(String value, int from) {
+        boolean inString = false;
+        char quote = 0;
+        for (int i = from; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (inString) {
+                if (c == '\\') {
+                    i++; // skip the escaped character
+                } else if (c == quote) {
+                    inString = false;
+                }
+            } else if (c == '"' || c == '\'') {
+                inString = true;
+                quote = c;
+            } else if (c == '}') {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipant.java
@@ -131,6 +131,15 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
     );
 
     /**
+     * Leaf elements whose text content is raw code (not a Synapse expression) and must not be
+     * scanned for vars.X references — e.g. a JS/Groovy script body could legitimately contain a
+     * ${...} template literal that is not a Synapse variable reference.
+     */
+    private static final Set<String> RAW_TEXT_ELEMENTS = new HashSet<>(Arrays.asList(
+            "script"
+    ));
+
+    /**
      * Regex to find $N placeholders in PayloadFactory format strings.
      */
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$(\\d+)");
@@ -1146,53 +1155,96 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
      */
     private void validateVariableReferences(DOMElement element, List<Diagnostic> diagnostics,
                                             DOMDocument document, Set<String> definedVariables) {
-        // Check all attributes for ${...} expressions containing vars.X
+        // Check all attribute values for ${...} expressions containing vars.X
         List<DOMAttr> attrs = element.getAttributeNodes();
-        if (attrs == null) {
+        if (attrs != null) {
+            for (DOMAttr attr : attrs) {
+                String attrValue = attr.getValue();
+                if (attrValue == null || (!attrValue.contains("vars.") && !attrValue.contains("vars["))) {
+                    continue;
+                }
+                checkContentForUndefinedVariables(attrValue, XMLPositionUtility.selectAttributeValue(attr),
+                        diagnostics, definedVariables);
+            }
+        }
+
+        // Check element text content too — e.g. connector operation parameters such as
+        // <q>{${vars.x}}</q> reference variables in text, not attributes.
+        validateVariableReferencesInText(element, diagnostics, document, definedVariables);
+    }
+
+    /**
+     * Scans the text content of a leaf element for ${...} expressions referencing undefined vars.X.
+     * Only leaf elements are inspected (containers expose their text via their leaf children), and
+     * raw-code elements (see {@link #RAW_TEXT_ELEMENTS}) are skipped to avoid false positives.
+     */
+    private void validateVariableReferencesInText(DOMElement element, List<Diagnostic> diagnostics,
+                                                  DOMDocument document, Set<String> definedVariables) {
+        if (hasChildElements(element)) {
             return;
         }
-        for (DOMAttr attr : attrs) {
-            String attrValue = attr.getValue();
-            if (attrValue == null || (!attrValue.contains("vars.") && !attrValue.contains("vars["))) {
+        String localName = element.getLocalName();
+        if (localName != null && RAW_TEXT_ELEMENTS.contains(localName.toLowerCase())) {
+            return;
+        }
+        List<DOMNode> children = element.getChildren();
+        if (children == null) {
+            return;
+        }
+        for (DOMNode child : children) {
+            if (!child.isText()) {
+                continue;
+            }
+            String text = child.getTextContent();
+            if (text == null || (!text.contains("vars.") && !text.contains("vars["))) {
+                continue;
+            }
+            Range range = XMLPositionUtility.createRange(child.getStart(), child.getEnd(), document);
+            checkContentForUndefinedVariables(text, range, diagnostics, definedVariables);
+        }
+    }
+
+    /**
+     * Extracts every ${...}/{${...}} expression from {@code content}, and for each vars.X reference
+     * to a name not in {@code definedVariables}, adds an UndefinedVariable warning anchored at
+     * {@code range}. Shared by the attribute-value and text-content reference checks.
+     */
+    private void checkContentForUndefinedVariables(String content, Range range,
+                                                   List<Diagnostic> diagnostics, Set<String> definedVariables) {
+        if (range == null) {
+            return;
+        }
+        Matcher exprMatcher = EXPRESSION_PATTERN.matcher(content);
+        while (exprMatcher.find()) {
+            String exprContent = exprMatcher.group(1);
+            if (exprContent == null) {
+                exprContent = exprMatcher.group(2); // {${...}} form
+            }
+            if (exprContent == null) {
                 continue;
             }
 
-            // Extract ${...} or {${...}} expressions from the attribute value
-            Matcher exprMatcher = EXPRESSION_PATTERN.matcher(attrValue);
-            while (exprMatcher.find()) {
-                String exprContent = exprMatcher.group(1);
-                if (exprContent == null) {
-                    exprContent = exprMatcher.group(2); // {${...}} form
-                }
-                if (exprContent == null) {
-                    continue;
-                }
+            // Find vars.X references within the expression
+            Matcher varsMatcher = VARS_REF_PATTERN.matcher(exprContent);
+            while (varsMatcher.find()) {
+                // Get the variable name from whichever group matched
+                String varName = varsMatcher.group(1);
+                if (varName == null) varName = varsMatcher.group(2);
+                if (varName == null) varName = varsMatcher.group(3);
 
-                // Find vars.X references within the expression
-                Matcher varsMatcher = VARS_REF_PATTERN.matcher(exprContent);
-                while (varsMatcher.find()) {
-                    // Get the variable name from whichever group matched
-                    String varName = varsMatcher.group(1);
-                    if (varName == null) varName = varsMatcher.group(2);
-                    if (varName == null) varName = varsMatcher.group(3);
-
-                    if (varName != null && !definedVariables.contains(varName)) {
-                        Range range = XMLPositionUtility.selectAttributeValue(attr);
-                        if (range != null) {
-                            Diagnostic d = new Diagnostic();
-                            d.setRange(range);
-                            d.setMessage(
-                                    "Variable '" + varName + "' is referenced but not defined in this file. " +
-                                            "If it is defined in a calling sequence, this warning can be ignored. " +
-                                            "Otherwise, define it using <variable name=\"" + varName +
-                                            "\" .../> before this point.");
-                            d.setSeverity(DiagnosticSeverity.Warning);
-                            d.setSource(SOURCE);
-                            d.setCode("UndefinedVariable");
-                            d.setData(varName);
-                            diagnostics.add(d);
-                        }
-                    }
+                if (varName != null && !definedVariables.contains(varName)) {
+                    Diagnostic d = new Diagnostic();
+                    d.setRange(range);
+                    d.setMessage(
+                            "Variable '" + varName + "' is referenced but not defined in this file. " +
+                                    "If it is defined in a calling sequence, this warning can be ignored. " +
+                                    "Otherwise, define it using <variable name=\"" + varName +
+                                    "\" .../> before this point.");
+                    d.setSeverity(DiagnosticSeverity.Warning);
+                    d.setSource(SOURCE);
+                    d.setCode("UndefinedVariable");
+                    d.setData(varName);
+                    diagnostics.add(d);
                 }
             }
         }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipant.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -72,12 +73,48 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
     private static final long ARTIFACT_CACHE_TTL_MS = 5000; // 5 seconds
     private final Map<String, CachedArtifactIndex> artifactIndexCache = new ConcurrentHashMap<>();
 
+    /**
+     * Invalidation signal for {@link #artifactIndexCache}. The cache is keyed per project with a
+     * short TTL; when an artifact/resource file under {@code src/main/wso2mi} changes, the language
+     * server bumps this epoch so the next diagnostics run rebuilds the index instead of serving a
+     * stale entry (which would wrongly flag a just-written sibling as unresolved for up to the TTL).
+     * A cache entry is only honored while its stored epoch matches the current one.
+     */
+    private static final AtomicLong artifactCacheEpoch = new AtomicLong();
+
+    /** Invalidate the cross-file artifact index cache (call when project artifact files change). */
+    public static void invalidateArtifactIndexCache() {
+        artifactCacheEpoch.incrementAndGet();
+    }
+
     /** Template name -> absolute file path, populated during artifact index building. */
     private volatile Map<String, String> templateFilePaths = java.util.Collections.emptyMap();
     /** Artifact names that appear in multiple files (duplicates). */
     private volatile Set<String> duplicateArtifactNames = java.util.Collections.emptySet();
     /** Artifact names that participate in direct circular references (A->B->A). */
     private volatile Set<String> cyclicArtifacts = java.util.Collections.emptySet();
+
+    /**
+     * Request-scoped opt-out for cross-file (other-artifact-dependent) checks. The MI Copilot agent
+     * sets this for per-file auto-validation after a write, when sibling artifacts it references may
+     * not exist on disk yet, to suppress transient false positives. It is thread-confined and set by
+     * {@code SynapseLanguageService.codeDiagnostic()} around the {@code doDiagnostics} call; the
+     * editor/manual flows never set it, so cross-file validation stays on by default.
+     */
+    private static final ThreadLocal<Boolean> SKIP_CROSS_FILE_VALIDATION =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    public static void setSkipCrossFileValidation(boolean skip) {
+        SKIP_CROSS_FILE_VALIDATION.set(skip);
+    }
+
+    public static void clearSkipCrossFileValidation() {
+        SKIP_CROSS_FILE_VALIDATION.remove();
+    }
+
+    private static boolean isSkipCrossFileValidation() {
+        return Boolean.TRUE.equals(SKIP_CROSS_FILE_VALIDATION.get());
+    }
 
     private static final Set<String> SYNAPSE_ROOT_ELEMENTS = new HashSet<>(Arrays.asList(
             "api", "proxy", "endpoint", "sequence", "inboundEndpoint", "template",
@@ -158,8 +195,13 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
             "api", "proxy", "sequence", "inboundEndpoint", "resource"
     ));
 
+    // Synchronized because a single participant instance is registered in SynapsePlugin and
+    // diagnostics can run concurrently (editor validation and codeDiagnostic both execute async).
+    // The cross-file index is derived into shared instance fields per run, so serializing here keeps
+    // one request from clearing/overwriting that state while another is still validating. Runs are
+    // short (the project scan is cached), so the contention cost is minimal.
     @Override
-    public void doDiagnostics(DOMDocument xmlDocument, List<Diagnostic> diagnostics,
+    public synchronized void doDiagnostics(DOMDocument xmlDocument, List<Diagnostic> diagnostics,
                               XMLValidationSettings validationSettings, CancelChecker cancelChecker) {
         DOMElement root = xmlDocument.getDocumentElement();
         if (root == null) {
@@ -173,7 +215,18 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
         if (SYNAPSE_NS.equals(namespace)) {
             // Valid Synapse file — run all validations
             Set<String> definedVariables = new HashSet<>();
-            Set<String> knownArtifacts = buildArtifactNameIndex(xmlDocument, cancelChecker);
+            // Cross-file reference checks depend on the project-wide artifact index. When the caller
+            // opts out (agent per-file validation) the index is not built, avoiding the filesystem
+            // scan; it is also null when the project path is not derivable. In either case the
+            // index is unavailable, so clear the derived cross-file state — otherwise a stale index
+            // from a prior request could surface template/duplicate/cycle diagnostics here.
+            boolean skipCrossFile = isSkipCrossFileValidation();
+            Set<String> knownArtifacts = skipCrossFile ? null : buildArtifactNameIndex(xmlDocument, cancelChecker);
+            if (knownArtifacts == null) {
+                this.templateFilePaths = java.util.Collections.emptyMap();
+                this.duplicateArtifactNames = java.util.Collections.emptySet();
+                this.cyclicArtifacts = java.util.Collections.emptySet();
+            }
 
             // Detect MI runtime version for new-pattern hints
             String projectPath = deriveProjectPath(xmlDocument);
@@ -965,6 +1018,8 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
      * P1-14: Validate call-template with-param names against template parameter declarations.
      */
     private void validateCallTemplateParams(DOMElement element, List<Diagnostic> diagnostics) {
+        // Cross-file check: depends on the referenced template file (cycles + parameter declarations)
+        if (isSkipCrossFileValidation()) return;
         String target = element.getAttribute("target");
         if (StringUtils.isEmpty(target) || isExpression(target)) return;
 
@@ -1071,6 +1126,7 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
      * P1-19: Warn if the current document's root artifact name is duplicated in the project.
      */
     private void validateDuplicateArtifactName(DOMElement root, List<Diagnostic> diagnostics) {
+        if (isSkipCrossFileValidation()) return; // cross-file check: needs the project-wide index
         if (duplicateArtifactNames.isEmpty()) return;
         String name = root.getAttribute("name");
         if (name != null && duplicateArtifactNames.contains(name)) {
@@ -1196,7 +1252,9 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
             return;
         }
         for (DOMNode child : children) {
-            if (!child.isText()) {
+            // Include CDATA: inline JSON/XML payloads (e.g. payloadFactory <format>) commonly wrap
+            // ${vars.x} references in <![CDATA[...]]>.
+            if (!child.isText() && !child.isCDATA()) {
                 continue;
             }
             String text = child.getTextContent();
@@ -1285,7 +1343,8 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
             return;
         }
         for (DOMNode child : children) {
-            if (!child.isText()) {
+            // Include CDATA: ${...} can appear inside <![CDATA[...]]> payloads too.
+            if (!child.isText() && !child.isCDATA()) {
                 continue;
             }
             String text = child.getTextContent();
@@ -1521,9 +1580,14 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
             return null;
         }
 
+        // Read the invalidation epoch up front: a cache entry built before the latest file change
+        // is treated as a miss even within its TTL, so a just-written sibling is picked up at once.
+        long epoch = artifactCacheEpoch.get();
+
         // Check cache first
         CachedArtifactIndex cached = artifactIndexCache.get(projectPath);
-        if (cached != null && (System.currentTimeMillis() - cached.timestamp) < ARTIFACT_CACHE_TTL_MS) {
+        if (cached != null && cached.epoch == epoch
+                && (System.currentTimeMillis() - cached.timestamp) < ARTIFACT_CACHE_TTL_MS) {
             // Restore all derived state so cross-reference checks see the same
             // template paths, duplicates, and cycles as a fresh build would.
             this.templateFilePaths = cached.templateFilePaths;
@@ -1568,7 +1632,7 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
         this.duplicateArtifactNames = duplicates;
         this.cyclicArtifacts = cycles;
         artifactIndexCache.put(projectPath, new CachedArtifactIndex(
-                artifactNames, templatePaths, duplicates, cycles, System.currentTimeMillis()));
+                artifactNames, templatePaths, duplicates, cycles, System.currentTimeMillis(), epoch));
         return artifactNames;
     }
 
@@ -2372,17 +2436,20 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
         final Set<String> duplicateArtifactNames;
         final Set<String> cyclicArtifacts;
         final long timestamp;
+        final long epoch;
 
         CachedArtifactIndex(Set<String> artifactNames,
                             Map<String, String> templateFilePaths,
                             Set<String> duplicateArtifactNames,
                             Set<String> cyclicArtifacts,
-                            long timestamp) {
+                            long timestamp,
+                            long epoch) {
             this.artifactNames = artifactNames;
             this.templateFilePaths = templateFilePaths;
             this.duplicateArtifactNames = duplicateArtifactNames;
             this.cyclicArtifacts = cyclicArtifacts;
             this.timestamp = timestamp;
+            this.epoch = epoch;
         }
     }
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/validator/SynapseExpressionValidator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/validator/SynapseExpressionValidator.java
@@ -64,7 +64,16 @@ public class SynapseExpressionValidator implements XMLComponent, XMLDocumentFilt
 
     private boolean isFileInArtifacts(String baseSystemId) {
 
-        return baseSystemId.contains(TryOutConstants.PROJECT_ARTIFACT_PATH.toString());
+        if (baseSystemId == null) {
+            return false;
+        }
+        // Compare with forward slashes so the check holds on every OS: the document system id is
+        // typically a file:// URI (always '/'), while PROJECT_ARTIFACT_PATH.toString() uses the
+        // platform separator ('\' on Windows) — without normalizing, the gate would never match on
+        // Windows and expression validation would silently not run there.
+        String normalizedId = baseSystemId.replace('\\', '/');
+        String artifactsPath = TryOutConstants.PROJECT_ARTIFACT_PATH.toString().replace('\\', '/');
+        return normalizedId.contains(artifactsPath);
     }
 
     @Override

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/CodeDiagnosticFileNameTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/CodeDiagnosticFileNameTest.java
@@ -52,7 +52,8 @@ public class CodeDiagnosticFileNameTest extends AbstractCacheBasedTest {
     private static final String SYNAPSE_NS = "http://ws.apache.org/ns/synapse";
     private static final String SYNAPSE_CATALOG_440 =
             "src/main/resources/org/eclipse/lemminx/schemas/440/catalog.xml";
-    // An absolute path under the project artifacts directory, as the MI extension sends.
+    // An absolute path under the project artifacts directory, as the MI extension sends. The
+    // SynapseExpressionValidator gate is separator-agnostic, so this forward-slash URI works on all OSes.
     private static final String ARTIFACT_URI =
             "/home/proj/src/main/wso2mi/artifacts/sequences/Test.xml";
 
@@ -143,5 +144,15 @@ public class CodeDiagnosticFileNameTest extends AbstractCacheBasedTest {
         assertEquals(UNPARENTHESIZED, request.getCode());
         assertEquals(ARTIFACT_URI, request.getFileName(),
                 "CodeDiagnosticRequest must carry the fileName sent by the extension");
+    }
+
+    @Test
+    public void testCodeDiagnosticRequestSkipCrossFileDefaultsFalse() {
+        org.eclipse.lemminx.customservice.synapse.CodeDiagnosticRequest request =
+                new org.eclipse.lemminx.customservice.synapse.CodeDiagnosticRequest();
+        assertFalse(request.isSkipCrossFileValidation(),
+                "skipCrossFileValidation must default to false so the editor/validate-all paths are unchanged");
+        request.setSkipCrossFileValidation(true);
+        assertTrue(request.isSkipCrossFileValidation());
     }
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/CodeDiagnosticFileNameTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/CodeDiagnosticFileNameTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     WSO2 LLC - support for WSO2 Micro Integrator Configuration
+ */
+
+package org.eclipse.lemminx.extensions.synapse;
+
+import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.customservice.synapse.utils.Utils;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationRootSettings;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the {@code synapse/codeDiagnostic} document-URI plumbing.
+ *
+ * <p>The MI Copilot agent validates in-memory (unsaved) code via {@code synapse/codeDiagnostic}.
+ * Before the fix this path parsed the code with the literal URI {@code "temp"}, which made the
+ * URI-gated {@code SynapseExpressionValidator} (it only runs for files under
+ * {@code src/main/wso2mi/artifacts}) silently skip every expression diagnostic. The fix lets the
+ * caller supply the real file name as the document URI (with {@code "temp"} as the backward
+ * compatible fallback).
+ *
+ * <p>These tests exercise the exact pipeline {@code SynapseLanguageService.codeDiagnostic()} runs
+ * internally — {@code Utils.getDOMDocument(code, uri, resolver)} followed by
+ * {@code XMLLanguageService.doDiagnostics(...)} — and assert the operator-precedence warning is
+ * surfaced only when the URI is under the artifacts path.
+ */
+public class CodeDiagnosticFileNameTest extends AbstractCacheBasedTest {
+
+    private static final String SYNAPSE_NS = "http://ws.apache.org/ns/synapse";
+    private static final String SYNAPSE_CATALOG_440 =
+            "src/main/resources/org/eclipse/lemminx/schemas/440/catalog.xml";
+    // An absolute path under the project artifacts directory, as the MI extension sends.
+    private static final String ARTIFACT_URI =
+            "/home/proj/src/main/wso2mi/artifacts/sequences/Test.xml";
+
+    // <property> with an unparenthesized comparison/logical mix — the precedence pitfall.
+    private static final String UNPARENTHESIZED = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+            + "<property name=\"p\" expression=\"${payload.id &lt;= 0 or payload.id &gt; 10}\"/>"
+            + "</sequence>";
+    // The corrected, explicitly parenthesized form.
+    private static final String PARENTHESIZED = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+            + "<property name=\"p\" expression=\"${(payload.id &lt;= 0) or (payload.id &gt; 10)}\"/>"
+            + "</sequence>";
+
+    /**
+     * Reproduces the codeDiagnostic pipeline: build the DOM document with the given URI (via the
+     * fileName-aware overload the fix added), then run the full XML diagnostics pipeline.
+     */
+    private List<Diagnostic> codeDiagnostic(String code, String fileName) {
+        XMLLanguageService ls = new XMLLanguageService();
+        String uri = fileName != null ? fileName : "temp";
+        DOMDocument document = Utils.getDOMDocument(code, uri, ls.getResolverExtensionManager());
+        ls.setDocumentProvider(u -> document);
+
+        ContentModelSettings settings = new ContentModelSettings();
+        settings.setUseCache(false);
+        XMLValidationRootSettings validation = new XMLValidationRootSettings();
+        validation.setNoGrammar("ignore");
+        settings.setValidation(validation);
+        settings.setCatalogs(new String[]{SYNAPSE_CATALOG_440});
+        ls.doSave(new XMLAssert.SettingsSaveContext(settings));
+
+        return ls.doDiagnostics(document, settings.getValidation(), Collections.emptyMap(), () -> {});
+    }
+
+    private List<Diagnostic> precedenceWarnings(List<Diagnostic> diagnostics) {
+        return diagnostics.stream()
+                .filter(d -> d.getMessage() != null && d.getMessage().contains("Operator precedence"))
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testPrecedenceWarningReturnedForArtifactsPath() {
+        // With a real artifacts file name, the expression validator runs and reports the warning.
+        List<Diagnostic> diags = codeDiagnostic(UNPARENTHESIZED, ARTIFACT_URI);
+        assertFalse(precedenceWarnings(diags).isEmpty(),
+                "codeDiagnostic with an artifacts file name should surface the operator-precedence warning");
+    }
+
+    @Test
+    public void testNoPrecedenceWarningForParenthesizedExpression() {
+        // The corrected, parenthesized form must not be flagged even on the artifacts path.
+        List<Diagnostic> diags = codeDiagnostic(PARENTHESIZED, ARTIFACT_URI);
+        assertTrue(precedenceWarnings(diags).isEmpty(),
+                "Parenthesized comparisons should produce no operator-precedence warning");
+    }
+
+    @Test
+    public void testTempFallbackDocumentsUnchangedBehavior() {
+        // Backward compatibility: a null file name falls back to "temp", which is not under the
+        // artifacts path, so the expression validator stays disabled (unchanged pre-fix behavior).
+        List<Diagnostic> diags = codeDiagnostic(UNPARENTHESIZED, null);
+        assertTrue(precedenceWarnings(diags).isEmpty(),
+                "The \"temp\" fallback keeps the expression validator disabled, as before the fix");
+    }
+
+    // ===== URI plumbing unit checks (deterministic, no validation pipeline) =====
+
+    @Test
+    public void testGetDOMDocumentUsesProvidedUri() {
+        DOMDocument document = Utils.getDOMDocument(UNPARENTHESIZED, ARTIFACT_URI, null);
+        assertEquals(ARTIFACT_URI, document.getDocumentURI(),
+                "The 3-arg overload should assign the supplied URI to the document");
+    }
+
+    @Test
+    public void testGetDOMDocumentDefaultStillUsesTemp() {
+        // The legacy overloads (which delegate with no URI) must keep the "temp" URI unchanged.
+        DOMDocument document = Utils.getDOMDocument(UNPARENTHESIZED);
+        assertEquals("temp", document.getDocumentURI(),
+                "The legacy overloads should keep the \"temp\" URI for backward compatibility");
+    }
+
+    @Test
+    public void testCodeDiagnosticRequestCarriesFileName() {
+        org.eclipse.lemminx.customservice.synapse.CodeDiagnosticRequest request =
+                new org.eclipse.lemminx.customservice.synapse.CodeDiagnosticRequest();
+        request.setCode(UNPARENTHESIZED);
+        request.setFileName(ARTIFACT_URI);
+        assertEquals(UNPARENTHESIZED, request.getCode());
+        assertEquals(ARTIFACT_URI, request.getFileName(),
+                "CodeDiagnosticRequest must carry the fileName sent by the extension");
+    }
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipantTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipantTest.java
@@ -606,6 +606,33 @@ public class SynapseDiagnosticsParticipantTest {
         assertTrue(diags.isEmpty(), "Script bodies must not be scanned for unclosed expressions");
     }
 
+    // ===== CDATA payloads are scanned too =====
+
+    @Test
+    public void testUndefinedVariableInCdataWarns() {
+        // ${vars.x} inside a CDATA payload (e.g. payloadFactory format) must still be validated.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<payloadFactory media-type=\"json\">"
+                + "<format><![CDATA[{\"id\": \"${vars.missingCdata}\"}]]></format>"
+                + "</payloadFactory>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertEquals(1, diags.size(), "Undefined variable referenced inside CDATA should warn");
+        assertTrue(diags.get(0).getMessage().contains("missingCdata"));
+    }
+
+    @Test
+    public void testUnclosedExpressionInCdataWarns() {
+        // An unclosed ${ inside a CDATA payload must still be flagged.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<payloadFactory media-type=\"json\">"
+                + "<format><![CDATA[{\"id\": \"${payload.id\"}]]></format>"
+                + "</payloadFactory>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UnclosedExpression");
+        assertEquals(1, diags.size(), "Unclosed ${ inside CDATA should warn");
+    }
+
     // ===== Non-Synapse document skipping =====
 
     @Test
@@ -1656,6 +1683,7 @@ public class SynapseDiagnosticsParticipantTest {
             originalUserHome = null;
         }
         SynapseLanguageService.setLoadedResourceFinder(null);
+        SynapseDiagnosticsParticipant.clearSkipCrossFileValidation();
     }
 
     /**
@@ -1743,5 +1771,140 @@ public class SynapseDiagnosticsParticipantTest {
         List<Diagnostic> unresolved = diagnosticsWithCode(diags, "UnresolvedArtifactReference");
         assertEquals(1, unresolved.size());
         assertTrue(unresolved.get(0).getMessage().contains("reallyDoesNotExist"));
+    }
+
+    // ===== skipCrossFileValidation opt-out (Change 1) =====
+
+    /** As {@link #diagnoseAtPath(String, Path)} but with the request-scoped cross-file opt-out set. */
+    private List<Diagnostic> diagnoseAtPath(String xml, Path xmlFilePath, boolean skipCrossFile) throws Exception {
+        try {
+            SynapseDiagnosticsParticipant.setSkipCrossFileValidation(skipCrossFile);
+            return diagnoseAtPath(xml, xmlFilePath);
+        } finally {
+            SynapseDiagnosticsParticipant.clearSkipCrossFileValidation();
+        }
+    }
+
+    @Test
+    public void testSkipCrossFileValidationSuppressesUnresolvedButKeepsWithinFileChecks(@TempDir Path tempDir)
+            throws Exception {
+        originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempDir.toString());
+
+        Path consumer = tempDir.resolve("consumer");
+        Path apiXml = consumer.resolve("src/main/wso2mi/artifacts/apis/cvh.xml");
+        // References a sequence that does not exist (cross-file) AND an undefined variable (within-file).
+        String xml = "<api xmlns=\"" + SYNAPSE_NS + "\" name=\"cvh\" context=\"/cvh\">"
+                + "<resource methods=\"GET\" uri-template=\"/\"><inSequence>"
+                + "<property name=\"p\" expression=\"${vars.undefinedVar}\"/>"
+                + "<sequence key=\"doesNotExist\"/>"
+                + "</inSequence></resource></api>";
+
+        List<Diagnostic> diags = diagnoseAtPath(xml, apiXml, true);
+        assertTrue(diagnosticsWithCode(diags, "UnresolvedArtifactReference").isEmpty(),
+                "skipCrossFileValidation must suppress the cross-file UnresolvedArtifactReference");
+        assertEquals(1, diagnosticsWithCode(diags, "UndefinedVariable").size(),
+                "Within-file UndefinedVariable must still be reported when cross-file checks are skipped");
+    }
+
+    @Test
+    public void testCrossFileValidationDefaultStillFlagsUnresolved(@TempDir Path tempDir) throws Exception {
+        originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempDir.toString());
+
+        Path consumer = tempDir.resolve("consumer");
+        Path apiXml = consumer.resolve("src/main/wso2mi/artifacts/apis/cvh.xml");
+        String xml = "<api xmlns=\"" + SYNAPSE_NS + "\" name=\"cvh\" context=\"/cvh\">"
+                + "<resource methods=\"GET\" uri-template=\"/\"><inSequence>"
+                + "<sequence key=\"doesNotExist\"/>"
+                + "</inSequence></resource></api>";
+
+        // Default (flag false) — cross-file validation runs and flags the unresolved reference.
+        List<Diagnostic> diags = diagnoseAtPath(xml, apiXml, false);
+        assertEquals(1, diagnosticsWithCode(diags, "UnresolvedArtifactReference").size(),
+                "With cross-file validation on (default), an unresolved reference must still be flagged");
+    }
+
+    // ===== Cached artifact index invalidation (Change 2) =====
+
+    /** Runs diagnostics with a caller-supplied participant so its artifact-index cache persists across calls. */
+    private List<Diagnostic> diagnoseAtPathWith(SynapseDiagnosticsParticipant participant, String xml,
+                                                Path xmlFilePath) throws Exception {
+        Files.createDirectories(xmlFilePath.getParent());
+        Files.writeString(xmlFilePath, xml);
+        TextDocument textDocument = new TextDocument(xml, xmlFilePath.toUri().toString());
+        DOMDocument document = DOMParser.getInstance().parse(textDocument, null);
+        List<Diagnostic> diagnostics = new ArrayList<>();
+        participant.doDiagnostics(document, diagnostics, null, () -> {});
+        return diagnostics;
+    }
+
+    @Test
+    public void testInvalidateArtifactIndexCacheRebuildsAfterFileChange(@TempDir Path tempDir) throws Exception {
+        originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempDir.toString());
+
+        Path consumer = tempDir.resolve("consumer");
+        Path apiXml = consumer.resolve("src/main/wso2mi/artifacts/apis/cvh.xml");
+        String api = "<api xmlns=\"" + SYNAPSE_NS + "\" name=\"cvh\" context=\"/cvh\">"
+                + "<resource methods=\"GET\" uri-template=\"/\"><inSequence>"
+                + "<sequence key=\"sibling\"/></inSequence></resource></api>";
+
+        // Reuse one participant so its cross-file index cache survives across calls (as in production).
+        SynapseDiagnosticsParticipant participant = new SynapseDiagnosticsParticipant();
+
+        // 1. Sibling does not exist yet -> unresolved, and the index is now cached for this project.
+        List<Diagnostic> first = diagnoseAtPathWith(participant, api, apiXml);
+        assertEquals(1, diagnosticsWithCode(first, "UnresolvedArtifactReference").size(),
+                "Sibling 'sibling' does not exist yet -> should be flagged unresolved");
+
+        // 2. Write the sibling on disk. Within the TTL and without invalidation the cache is stale.
+        Path siblingXml = consumer.resolve("src/main/wso2mi/artifacts/sequences/sibling.xml");
+        Files.createDirectories(siblingXml.getParent());
+        Files.writeString(siblingXml, "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"sibling\"><log/></sequence>");
+
+        List<Diagnostic> stale = diagnoseAtPathWith(participant, api, apiXml);
+        assertEquals(1, diagnosticsWithCode(stale, "UnresolvedArtifactReference").size(),
+                "Within the TTL and without invalidation, the stale cached index still flags it unresolved");
+
+        // 3. Invalidate -> the next run rebuilds the index and resolves the now-present sibling.
+        SynapseDiagnosticsParticipant.invalidateArtifactIndexCache();
+        List<Diagnostic> fresh = diagnoseAtPathWith(participant, api, apiXml);
+        assertTrue(diagnosticsWithCode(fresh, "UnresolvedArtifactReference").isEmpty(),
+                "After invalidation the rebuilt index includes the new sibling -> no longer unresolved");
+    }
+
+    @Test
+    public void testStaleCrossFileStateNotLeakedWhenIndexUnavailable(@TempDir Path tempDir) throws Exception {
+        originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempDir.toString());
+
+        Path project = tempDir.resolve("proj");
+        // Two artifacts sharing a name -> "DupSeq" becomes a known duplicate for this project.
+        Path seqA = project.resolve("src/main/wso2mi/artifacts/sequences/a.xml");
+        Path seqB = project.resolve("src/main/wso2mi/artifacts/sequences/b.xml");
+        Files.createDirectories(seqA.getParent());
+        Files.writeString(seqA, "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"DupSeq\"><log/></sequence>");
+        Files.writeString(seqB, "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"DupSeq\"><log/></sequence>");
+
+        // Reuse one participant so its instance-level cross-file state persists across requests.
+        SynapseDiagnosticsParticipant participant = new SynapseDiagnosticsParticipant();
+
+        // Request A: validate a doc inside the project so the duplicate index is built into the
+        // participant's instance state (duplicateArtifactNames = { "DupSeq" }).
+        Path apiXml = project.resolve("src/main/wso2mi/artifacts/apis/cvh.xml");
+        diagnoseAtPathWith(participant, "<api xmlns=\"" + SYNAPSE_NS + "\" name=\"cvh\" context=\"/cvh\">"
+                + "<resource methods=\"GET\" uri-template=\"/\"><inSequence><respond/></inSequence></resource></api>",
+                apiXml);
+
+        // Request B (same participant): a doc named "DupSeq" whose project path is not derivable, so
+        // the cross-file index is unavailable. The stale duplicate state must be cleared, not reused.
+        TextDocument textB = new TextDocument(
+                "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"DupSeq\"><log/></sequence>", "test.xml");
+        DOMDocument docB = DOMParser.getInstance().parse(textB, null);
+        List<Diagnostic> diagsB = new ArrayList<>();
+        participant.doDiagnostics(docB, diagsB, null, () -> {});
+        assertTrue(diagnosticsWithCode(diagsB, "DuplicateArtifactName").isEmpty(),
+                "Stale cross-file duplicate state must not leak to a request with no project index");
     }
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipantTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipantTest.java
@@ -468,6 +468,76 @@ public class SynapseDiagnosticsParticipantTest {
         assertTrue(diags.isEmpty(), "responseVariable child element should define the variable");
     }
 
+    // ===== Variable references in element text content (Issue #4) =====
+
+    @Test
+    public void testUndefinedVariableInElementText() {
+        // Connector operation parameter references vars.X in element text, not in an attribute.
+        // 'soqlQuery1' is a typo for the defined 'soqlQuery' — this is the exact MI Copilot case.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<variable name=\"soqlQuery\" type=\"STRING\" value=\"SELECT Id, Name FROM Account LIMIT 200\"/>"
+                + "<salesforce.query configKey=\"SalesforceConn\">"
+                + "<q>{${vars.soqlQuery1}}</q>"
+                + "<responseVariable>sfResponse</responseVariable>"
+                + "<overwriteBody>false</overwriteBody>"
+                + "</salesforce.query>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertEquals(1, diags.size(), "Undefined variable referenced in element text should warn");
+        assertEquals(DiagnosticSeverity.Warning, diags.get(0).getSeverity());
+        assertTrue(diags.get(0).getMessage().contains("soqlQuery1"));
+    }
+
+    @Test
+    public void testDefinedVariableInElementTextNoWarning() {
+        // The correctly-spelled variable referenced in element text should not warn.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<variable name=\"soqlQuery\" type=\"STRING\" value=\"SELECT Id FROM Account\"/>"
+                + "<salesforce.query configKey=\"SalesforceConn\">"
+                + "<q>{${vars.soqlQuery}}</q>"
+                + "<responseVariable>sfResponse</responseVariable>"
+                + "</salesforce.query>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertTrue(diags.isEmpty(), "Defined variable referenced in element text should not warn");
+    }
+
+    @Test
+    public void testUndefinedVariableInElementTextPlainExpressionForm() {
+        // The plain ${...} form (not {${...}}) inside element text should also be detected.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<payloadFactory media-type=\"json\">"
+                + "<format>{\"id\": \"${vars.missingId}\"}</format>"
+                + "</payloadFactory>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertEquals(1, diags.size(), "Undefined variable in ${...} text form should warn");
+        assertTrue(diags.get(0).getMessage().contains("missingId"));
+    }
+
+    @Test
+    public void testScriptBodyNotScannedForVariables() {
+        // Raw-code (script) bodies must not be treated as Synapse expressions (no false positives).
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<script language=\"js\">var s = \"${vars.notReal}\";</script>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertTrue(diags.isEmpty(), "Script body should not be scanned for variable references");
+    }
+
+    @Test
+    public void testPlainTextWithoutExpressionNoWarning() {
+        // Element text that merely contains the literal 'vars.' but no ${...} expression must not warn.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<salesforce.query configKey=\"SalesforceConn\">"
+                + "<q>SELECT vars.field FROM Account</q>"
+                + "<responseVariable>sfResponse</responseVariable>"
+                + "</salesforce.query>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertTrue(diags.isEmpty(), "Plain text without a ${...} expression should not warn");
+    }
+
     // ===== Non-Synapse document skipping =====
 
     @Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipantTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipantTest.java
@@ -538,6 +538,74 @@ public class SynapseDiagnosticsParticipantTest {
         assertTrue(diags.isEmpty(), "Plain text without a ${...} expression should not warn");
     }
 
+    // ===== Unclosed expression delimiters =====
+
+    @Test
+    public void testUnclosedExpressionInAttributeWarns() {
+        // '${' opened but never closed — previously treated as a plain string with no feedback.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<property name=\"p\" expression=\"${payload.count > 0\"/>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UnclosedExpression");
+        assertEquals(1, diags.size(), "An unclosed ${ in an attribute should warn");
+        assertEquals(DiagnosticSeverity.Warning, diags.get(0).getSeverity());
+        assertTrue(diags.get(0).getMessage().contains("Unclosed expression"));
+    }
+
+    @Test
+    public void testClosedExpressionInAttributeNoWarning() {
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<property name=\"p\" expression=\"${payload.count > 0}\"/>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UnclosedExpression");
+        assertTrue(diags.isEmpty(), "A properly closed ${...} must not be flagged");
+    }
+
+    @Test
+    public void testUnclosedExpressionInElementTextWarns() {
+        // Same gap in element text (e.g. a connector operation parameter).
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<salesforce.query configKey=\"C\">"
+                + "<q>${payload.count</q>"
+                + "</salesforce.query>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UnclosedExpression");
+        assertEquals(1, diags.size(), "An unclosed ${ in element text should warn");
+        assertTrue(diags.get(0).getMessage().contains("Unclosed expression"));
+    }
+
+    @Test
+    public void testWrappedClosedExpressionNoWarning() {
+        // The {${...}} form, properly closed, must not be flagged as unclosed.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<variable name=\"q\" type=\"STRING\" value=\"x\"/>"
+                + "<salesforce.query configKey=\"C\"><q>{${vars.q}}</q></salesforce.query>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UnclosedExpression");
+        assertTrue(diags.isEmpty(), "A closed {${...}} expression must not be flagged");
+    }
+
+    @Test
+    public void testExpressionWithBraceInStringLiteralNoWarning() {
+        // A '}' inside a string literal must not be mistaken for the closing delimiter, and the
+        // real closing '}' must still be recognized — so this valid expression is not flagged.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<property name=\"p\" expression=\"${concat('}', payload.x)}\"/>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UnclosedExpression");
+        assertTrue(diags.isEmpty(), "A brace inside a string literal must not cause a false positive");
+    }
+
+    @Test
+    public void testScriptBodyUnclosedExpressionNotFlagged() {
+        // Raw-code (script) bodies are excluded — a ${ in JS is not a Synapse expression.
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<script language=\"js\">var s = \"${notReal\";</script>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UnclosedExpression");
+        assertTrue(diags.isEmpty(), "Script bodies must not be scanned for unclosed expressions");
+    }
+
     // ===== Non-Synapse document skipping =====
 
     @Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/expression/ExpressionValidatorTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/synapse/expression/ExpressionValidatorTest.java
@@ -441,4 +441,68 @@ public class ExpressionValidatorTest {
         List<ExpressionError> errors = ExpressionValidator.validate("payload[0]");
         assertTrue(errors.isEmpty(), "Zero array index should produce no warnings");
     }
+
+    // ===== Operator precedence: logical operator (and/or) as a comparison operand =====
+    // In the Synapse expression grammar 'and'/'or' bind TIGHTER than the comparison operators,
+    // so 'a <= 0 or b > 10' parses as 'a <= (0 or b) > 10' rather than '(a <= 0) or (b > 10)'.
+
+    @Test
+    public void testOrBindsTighterThanComparisonWarns() {
+        // Parses as payload.id <= (0 or payload.id) > 10 — almost certainly not intended.
+        List<ExpressionError> errors = ExpressionValidator.validate("payload.id <= 0 or payload.id > 10");
+        assertEquals(1, errors.size(), "Mixing 'or' with comparisons without parentheses should warn once");
+        assertTrue(errors.get(0).getMessage().contains("Operator precedence"),
+                "Should warn about operator precedence: " + errors.get(0).getMessage());
+        assertTrue(errors.get(0).isWarning(), "Precedence issue should be a warning, not an error");
+    }
+
+    @Test
+    public void testCopilotPrecedenceExampleWarns() {
+        // The exact expression MI Copilot generated (Issue #1).
+        List<ExpressionError> errors = ExpressionValidator.validate(
+                "integer(params.queryParams.id) <= 0 or integer(params.queryParams.id) > 10");
+        assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Operator precedence")),
+                "Copilot precedence example should produce a precedence warning");
+        assertTrue(errors.stream().filter(e -> e.getMessage().contains("Operator precedence"))
+                        .allMatch(ExpressionError::isWarning),
+                "Precedence diagnostic should be a warning");
+    }
+
+    @Test
+    public void testAndBindsTighterThanComparisonWarns() {
+        // Parses as (payload.a and payload.b) <= 5.
+        List<ExpressionError> errors = ExpressionValidator.validate("payload.a and payload.b <= 5");
+        assertEquals(1, errors.size(), "Mixing 'and' with a comparison without parentheses should warn once");
+        assertTrue(errors.get(0).getMessage().contains("Operator precedence"),
+                "Should warn about operator precedence: " + errors.get(0).getMessage());
+        assertTrue(errors.get(0).isWarning(), "Precedence issue should be a warning, not an error");
+    }
+
+    @Test
+    public void testParenthesizedComparisonsNoWarning() {
+        // The corrected form: each comparison wrapped in parentheses. No precedence ambiguity.
+        List<ExpressionError> errors = ExpressionValidator.validate(
+                "(payload.id <= 0) or (payload.id > 10)");
+        assertTrue(errors.isEmpty(), "Parenthesized comparisons should produce no precedence warning");
+    }
+
+    @Test
+    public void testPureLogicalExpressionNoWarning() {
+        // No comparison operator present — pure logical expression, nothing to flag.
+        List<ExpressionError> errors = ExpressionValidator.validate("payload.a and payload.b");
+        assertTrue(errors.isEmpty(), "Pure logical expression without a comparison should not warn");
+    }
+
+    @Test
+    public void testPureComparisonNoWarning() {
+        // No logical operator present — pure comparison, nothing to flag.
+        List<ExpressionError> errors = ExpressionValidator.validate("payload.x <= 10");
+        assertTrue(errors.isEmpty(), "Pure comparison without a logical operator should not warn");
+    }
+
+    @Test
+    public void testComparisonBetweenTwoAccessesNoWarning() {
+        List<ExpressionError> errors = ExpressionValidator.validate("payload.x < payload.y");
+        assertTrue(errors.isEmpty(), "Comparison between two accesses should not warn");
+    }
 }


### PR DESCRIPTION
## Summary

Improves the Synapse diagnostics shared by the MI VS Code extension and the MI Copilot agent. The agent validates generated XML via `synapse/codeDiagnostic`; these changes make that path surface real errors while suppressing transient false positives.

- **Operator precedence** — warn when a logical operator (`and`/`or`) is an unparenthesized operand of a comparison. In Synapse expressions `and`/`or` bind tighter than the comparison operators, so `${a <= 0 or b > 10}` parses as `a <= (0 or b) > 10` rather than `(a <= 0) or (b > 10)`.
- **Undefined variables in element text** — the `vars.X` undefined-variable check now also scans element text content (e.g. `<q>{${vars.x}}</q>`), not just attribute values.
- **`synapse/codeDiagnostic` honors the file path** — the method now uses the request's `fileName` as the document URI, so path-gated diagnostics (expression validation, cross-file checks) run for the agent's in-memory validation instead of being silently dropped.
- **Unclosed `${` delimiters** — flag an opening `${` with no matching `}`, which was previously treated as a plain string.
- **`skipCrossFileValidation` opt-out** — an opt-in flag (default off) on `synapse/codeDiagnostic` lets the agent skip cross-file reference checks when validating a file before its referenced siblings are written. The editor and the explicit "validate all" path never set it and are unchanged.
- **Stale cross-file index** — the cached artifact index is refreshed when files under `src/main/wso2mi` change, so a just-written sibling is no longer wrongly flagged as unresolved.

All changes only add diagnostics for configurations that fail at runtime; valid configurations that pass today continue to pass, and deprecated-but-functional patterns are never flagged.

Related issue: wso2/product-integrator#1640
