### PR TITLE
Normalize path separators in artifact file-change cache invalidation

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -601,7 +601,8 @@ public class XMLTextDocumentService implements TextDocumentService {
 		computeAsync((monitor) -> {
 			// A document was saved, collect documents to revalidate
 			String savedUri = params.getTextDocument().getUri();
-			if (savedUri != null && savedUri.contains("src/main/wso2mi")) {
+			// LSP document URIs use '/', but normalize defensively so a backslash path also matches on Windows.
+			if (savedUri != null && savedUri.replace('\\', '/').contains("src/main/wso2mi")) {
 				// An artifact/resource file was saved — drop the cached cross-file index so the
 				// revalidation below (and sibling files) sees the updated set instead of stale data.
 				SynapseDiagnosticsParticipant.invalidateArtifactIndexCache();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLWorkspaceService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLWorkspaceService.java
@@ -100,7 +100,8 @@ public class XMLWorkspaceService implements WorkspaceService, IXMLCommandService
 			} else if (change.getUri().contains(Constant.CONNECTORS) && change.getUri().contains(".zip")) {
 				((SynapseLanguageService) xmlLanguageServer.getSynapseLanguageService()).updateConnectors();
 			} else {
-				if (change.getUri().contains("src/main/wso2mi")) {
+				// LSP URIs use '/', but normalize defensively so a backslash path also matches on Windows.
+				if (change.getUri().replace('\\', '/').contains("src/main/wso2mi")) {
 					// An artifact/resource file changed on disk — drop the cached cross-file index so
 					// the next diagnostics run rebuilds it (otherwise a just-written sibling stays
 					// "unresolved" for up to the cache TTL).


### PR DESCRIPTION
## Summary

Defensive hardening of the cross-file artifact-index cache invalidation added in #552.

`XMLTextDocumentService.didSave` and `XMLWorkspaceService.didChangeWatchedFiles` invalidate the cached cross-file index when a changed file's URI contains `src/main/wso2mi`. LSP document URIs use forward slashes on every OS, so this already works on Windows — but the URI separators are now normalized (`\` → `/`) before the substring check so a backslash path would match too, and to stay consistent with the separator-agnostic artifacts-path gate in `SynapseExpressionValidator`.

No behavior change on Linux/macOS; the normalization is a no-op on forward-slash URIs.
