### PR TITLE
Update OpenAPI spec generation process

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/APIGenerator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/APIGenerator.java
@@ -16,6 +16,7 @@ package org.eclipse.lemminx.customservice.synapse.api.generator;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.CommentMediator;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.api.API;
 import org.eclipse.lemminx.customservice.synapse.syntaxTree.pojo.api.APIResource;
@@ -51,12 +52,99 @@ public class APIGenerator {
 
     private JsonObject swaggerJson;
     private String publishSwaggerPath;
+    private String context;
+    private String version;
+    private String versionType;
     private static final Logger log = Logger.getLogger(APIGenerator.class.getName());
 
     public APIGenerator(JsonObject swaggerJson, String publishSwaggerPath) {
 
+        this(swaggerJson, publishSwaggerPath, null, null);
+    }
+
+    public APIGenerator(JsonObject swaggerJson, String publishSwaggerPath, String context) {
+
+        this(swaggerJson, publishSwaggerPath, context, null);
+    }
+
+    public APIGenerator(JsonObject swaggerJson, String publishSwaggerPath, String context, String version) {
+
+        this(swaggerJson, publishSwaggerPath, context, version, null);
+    }
+
+    public APIGenerator(JsonObject swaggerJson, String publishSwaggerPath, String context, String version,
+                        String versionType) {
+
         this.swaggerJson = swaggerJson;
         this.publishSwaggerPath = publishSwaggerPath;
+        this.context = context;
+        this.version = version;
+        this.versionType = versionType;
+    }
+
+    /**
+     * Normalize the optionally provided context so that it starts with '/' and has no trailing '/'.
+     *
+     * @return the normalized context, or null when no usable context was provided
+     */
+    private String getNormalizedProvidedContext() {
+
+        if (StringUtils.isBlank(context)) {
+            return null;
+        }
+        String resolved = context.trim();
+        // remove trailing '/'
+        if (resolved.length() > 1 && resolved.endsWith("/")) {
+            resolved = resolved.substring(0, resolved.length() - 1);
+        }
+        // add leading '/' if not present
+        if (!resolved.startsWith("/")) {
+            resolved = "/" + resolved;
+        }
+        if (StringUtils.isEmpty(resolved) || "/".equals(resolved)) {
+            return null;
+        }
+        return resolved;
+    }
+
+    /**
+     * Normalize the optionally provided version.
+     *
+     * @return the trimmed version, or null when no usable version was provided
+     */
+    private String getNormalizedProvidedVersion() {
+
+        if (StringUtils.isBlank(version)) {
+            return null;
+        }
+        return version.trim();
+    }
+
+    /**
+     * Normalize the optionally provided version type.
+     *
+     * @return the matching {@link ApiVersionType}, or null when no valid version type was provided
+     */
+    private ApiVersionType getNormalizedProvidedVersionType() {
+
+        if (StringUtils.isBlank(versionType)) {
+            return null;
+        }
+        try {
+            return ApiVersionType.valueOf(versionType.trim().toLowerCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Check whether the caller explicitly asked for the API to be unversioned.
+     *
+     * @return true when the provided version type is "none"
+     */
+    private boolean isProvidedVersionTypeNone() {
+
+        return StringUtils.equalsIgnoreCase(SwaggerConstants.VERSION_TYPE_NONE, StringUtils.trim(versionType));
     }
 
     public String generateSynapseAPIXml() {
@@ -81,40 +169,43 @@ public class APIGenerator {
      */
     public API generateSynapseAPI() throws APIGenException {
 
-        String apiContext;
-        if (swaggerJson.get(SwaggerConstants.SERVERS) == null ||
-                swaggerJson.get(SwaggerConstants.SERVERS).getAsJsonArray().size() == 0) {
-            apiContext = SwaggerConstants.DEFAULT_CONTEXT;
-        } else {
-            JsonObject firstServer = swaggerJson.getAsJsonArray(SwaggerConstants.SERVERS).get(0).getAsJsonObject();
-            // get the first path in the servers section
-            String serversString = firstServer.get(SwaggerConstants.URL).getAsString();
-            if (serversString.contains("{") && serversString.contains("}")) {
-                // url is templated, need to resolve
-                if (firstServer.has(SwaggerConstants.VARIABLES)) {
-                    JsonObject variables = firstServer.get(SwaggerConstants.VARIABLES).getAsJsonObject();
-                    serversString = replaceTemplates(serversString, variables);
-                } else {
-                    throw new APIGenException("Server url is templated, but variables cannot be found");
-                }
-            }
-            try {
-                URL url = new URL(serversString);
-                apiContext = url.getPath();
-            } catch (MalformedURLException e) {
-                // url can be relative the place where the swagger is hosted.
-                apiContext = serversString;
-            }
-            if (apiContext.isEmpty() || "/".equals(apiContext)) {
+        // A provided context always takes priority over the one derived from the swagger servers section
+        String apiContext = getNormalizedProvidedContext();
+        if (apiContext == null) {
+            if (swaggerJson.get(SwaggerConstants.SERVERS) == null ||
+                    swaggerJson.get(SwaggerConstants.SERVERS).getAsJsonArray().size() == 0) {
                 apiContext = SwaggerConstants.DEFAULT_CONTEXT;
-            }
-            //cleanup context : remove ending '/'
-            if (apiContext.lastIndexOf('/') == (apiContext.length() - 1)) {
-                apiContext = apiContext.substring(0, apiContext.length() - 1);
-            }
-            // add leading / if not exists
-            if (!apiContext.startsWith("/")) {
-                apiContext = "/" + apiContext;
+            } else {
+                JsonObject firstServer = swaggerJson.getAsJsonArray(SwaggerConstants.SERVERS).get(0).getAsJsonObject();
+                // get the first path in the servers section
+                String serversString = firstServer.get(SwaggerConstants.URL).getAsString();
+                if (serversString.contains("{") && serversString.contains("}")) {
+                    // url is templated, need to resolve
+                    if (firstServer.has(SwaggerConstants.VARIABLES)) {
+                        JsonObject variables = firstServer.get(SwaggerConstants.VARIABLES).getAsJsonObject();
+                        serversString = replaceTemplates(serversString, variables);
+                    } else {
+                        throw new APIGenException("Server url is templated, but variables cannot be found");
+                    }
+                }
+                try {
+                    URL url = new URL(serversString);
+                    apiContext = url.getPath();
+                } catch (MalformedURLException e) {
+                    // url can be relative the place where the swagger is hosted.
+                    apiContext = serversString;
+                }
+                if (StringUtils.isEmpty(apiContext) || "/".equals(apiContext)) {
+                    apiContext = SwaggerConstants.DEFAULT_CONTEXT;
+                }
+                //cleanup context : remove ending '/'
+                if (apiContext.lastIndexOf('/') == (apiContext.length() - 1)) {
+                    apiContext = apiContext.substring(0, apiContext.length() - 1);
+                }
+                // add leading / if not exists
+                if (!apiContext.startsWith("/")) {
+                    apiContext = "/" + apiContext;
+                }
             }
         }
 
@@ -129,23 +220,29 @@ public class APIGenerator {
 
         String apiName = swaggerInfo.get(SwaggerConstants.TITLE).getAsString();
 
-        // Extract version information
-        ApiVersionType versionType = null;
-        String version = "";
-        JsonElement swaggerVersionElement = swaggerInfo.get(SwaggerConstants.VERSION);
-        if (swaggerVersionElement != null && swaggerVersionElement.isJsonPrimitive() &&
-                swaggerVersionElement.getAsJsonPrimitive().isString()) {
-            version = swaggerVersionElement.getAsString();
-            if (apiContext.endsWith(version)) {
-                // If the base path ends with the version, then it will be considered as version-type=url
-                versionType = ApiVersionType.url;
-                //cleanup api context path : remove version from base path
-                apiContext = apiContext.substring(0, apiContext.length() - version.length() - 1);
-            } else {
-                // otherwise context based version strategy
-                versionType = ApiVersionType.context;
+        // Extract version information. A user provided version always takes priority over the values derived from the swagger info section.
+        String providedVersion = getNormalizedProvidedVersion();
+        ApiVersionType versionType = getNormalizedProvidedVersionType();
+        boolean versionTypeNone = isProvidedVersionTypeNone();
+        String swaggerVersion = null;
+        if (!versionTypeNone) {
+            JsonElement swaggerVersionElement = swaggerInfo.get(SwaggerConstants.VERSION);
+            if (swaggerVersionElement != null && swaggerVersionElement.isJsonPrimitive() &&
+                    swaggerVersionElement.getAsJsonPrimitive().isString()) {
+                swaggerVersion = swaggerVersionElement.getAsString();
             }
         }
+        String version = versionTypeNone ? StringUtils.EMPTY :
+                (StringUtils.isNotBlank(providedVersion) ? providedVersion : 
+                (StringUtils.isNotBlank(swaggerVersion) ? swaggerVersion : StringUtils.EMPTY));
+
+        if (ApiVersionType.url.equals(versionType)) {
+            String versionInPath = StringUtils.isNotBlank(swaggerVersion) ? swaggerVersion : version;
+            if (StringUtils.isNotEmpty(versionInPath) && apiContext.endsWith(versionInPath)) {
+                // remove version from base path
+                apiContext = apiContext.substring(0, apiContext.length() - versionInPath.length() - 1);
+			}
+		}
 
         // Create API
         API genAPI = new API();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/GenericApiObjectDefinition.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/GenericApiObjectDefinition.java
@@ -116,11 +116,10 @@ public class GenericApiObjectDefinition {
 
         if (resource.getUrlMapping() != null) {
             uri = StringEscapeUtils.unescapeHtml4(resource.getUrlMapping());
-            generateParameterList(parameterList, uri, false);
         } else {
             uri = StringEscapeUtils.unescapeHtml4(resource.getUriTemplate());
-            generateParameterList(parameterList, uri, true);
         }
+        generateParameterList(parameterList, uri);
         if (log.isLoggable(Level.FINE)) {
             log.info("Parameters processed for the URI + " + uri + " size " + parameterList.size());
         }
@@ -131,30 +130,15 @@ public class GenericApiObjectDefinition {
     }
 
     /**
-     * Generate URI and Path parameters for the given URI.
+     * Generate Path parameters for the given URI.
      *
-     * @param parameterList     List of maps to be populated with parameters
-     * @param uriString         URI string to be used to extract parameters
-     * @param generateBothTypes Indicates whether to consider both query and uri parameters. True if both to be
-     *                          considered.
+     * @param parameterList List of maps to be populated with parameters
+     * @param uriString     URI string to be used to extract parameters
      */
-    private static void generateParameterList(ArrayList<Map<String, Object>> parameterList, String uriString, boolean
-            generateBothTypes) {
+    private static void generateParameterList(ArrayList<Map<String, Object>> parameterList, String uriString) {
 
         if (uriString == null) {
             return;
-        }
-        if (generateBothTypes) {
-            String[] params = getQueryStringFromUrl(uriString).split("&");
-            for (String parameter : params) {
-                if (parameter != null) {
-                    int pos = parameter.indexOf('=');
-                    if (pos > 0) {
-                        parameterList.add(getParametersMap(parameter.substring(0, pos),
-                                SwaggerConstants.PARAMETER_IN_QUERY));
-                    }
-                }
-            }
         }
         Matcher matcher = SwaggerConstants.PATH_PARAMETER_PATTERN.matcher(getPathFromUrl(uriString));
         while (matcher.find()) {
@@ -235,21 +219,6 @@ public class GenericApiObjectDefinition {
             return uri.substring(0, pos);
         }
         return uri;
-    }
-
-    /**
-     * Get query parameter portion from the URI.
-     *
-     * @param uri String URI to be analysed
-     * @return String containing the URI parameter portion of the URI
-     */
-    private static String getQueryStringFromUrl(String uri) {
-
-        int pos = uri.indexOf("?");
-        if (pos > 0) {
-            return uri.substring(pos + 1);
-        }
-        return "";
     }
 
     /**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/RestApiAdmin.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/RestApiAdmin.java
@@ -103,8 +103,11 @@ public class RestApiAdmin {
         String endpoint = param.wsdlEndpointName;
         String publishSwaggerPath = param.publishSwaggerPath;
         String mode = param.mode;
+        String context = param.context;
+        String version = param.version;
+        String versionType = param.versionType;
 
-        return createAPI(apiName, sourcePath, endpoint, publishSwaggerPath, mode);
+        return createAPI(apiName, sourcePath, endpoint, publishSwaggerPath, mode, context, version, versionType);
     }
 
     /**
@@ -115,14 +118,18 @@ public class RestApiAdmin {
      * @param endpoint           WSDL endpoint
      * @param publishSwaggerPath Swagger publish path
      * @param mode               Mode of the API creation (Swagger / WSDL)
+     * @param context            API context, takes priority over the context derived from the swagger
+     * @param version            API version, takes priority over the version derived from the swagger
+     * @param versionType        API version type (url / context), takes priority over the version type
+     *                           derived from the swagger
      * @return
      */
     public GenerateAPIResponse createAPI(String apiName, String sourcePath, String endpoint, String publishSwaggerPath
-            , String mode) {
+            , String mode, String context, String version, String versionType) {
 
         if (CREATE_FROM_SWAGGER.equalsIgnoreCase(mode)) {
             try {
-                return createAPIFromSwagger(apiName, sourcePath, publishSwaggerPath);
+                return createAPIFromSwagger(apiName, sourcePath, publishSwaggerPath, context, version, versionType);
             } catch (JsonProcessingException e) {
                 LOGGER.log(Level.SEVERE, "Exception occurred while creating API from Swagger", e);
                 return new GenerateAPIResponse(null, null,
@@ -130,7 +137,7 @@ public class RestApiAdmin {
             }
         } else if (CREATE_FROM_WSDL.equalsIgnoreCase(mode)) {
             try {
-                return createAPIFromWSDL(apiName, endpoint, sourcePath);
+                return createAPIFromWSDL(apiName, endpoint, sourcePath, context, version, versionType);
             } catch (SOAPToRESTException e) {
                 LOGGER.log(Level.SEVERE, "Exception occurred while converting SOAP to REST", e);
                 return new GenerateAPIResponse(null, null,
@@ -147,26 +154,26 @@ public class RestApiAdmin {
         return null;
     }
 
-    private GenerateAPIResponse createAPIFromSwagger(String apiName, String swaggerPath, String publishSwaggerPath) throws JsonProcessingException {
+    private GenerateAPIResponse createAPIFromSwagger(String apiName, String swaggerPath, String publishSwaggerPath, String context, String version, String versionType) throws JsonProcessingException {
 
         File swaggerFile = new File(swaggerPath);
         String swaggerYaml = getSwaggerFileAsYAML(swaggerFile, apiName);
 
-        String api = getSynapseAPIFromSwagger(swaggerYaml, publishSwaggerPath);
+        String api = getSynapseAPIFromSwagger(swaggerYaml, publishSwaggerPath, context, version, versionType);
         return new GenerateAPIResponse(api);
     }
 
-    private String getSynapseAPIFromSwagger(String swaggerYaml, String publishSwaggerPath) throws JsonProcessingException {
+    private String getSynapseAPIFromSwagger(String swaggerYaml, String publishSwaggerPath, String context, String version, String versionType) throws JsonProcessingException {
 
         String swaggerString = GenericApiObjectDefinition.convertYamlToJson(swaggerYaml);
         JsonParser jsonParser = new JsonParser();
         JsonElement swaggerJson = jsonParser.parse(swaggerString);
-        APIGenerator apiGenerator = new APIGenerator(swaggerJson.getAsJsonObject(), publishSwaggerPath);
+        APIGenerator apiGenerator = new APIGenerator(swaggerJson.getAsJsonObject(), publishSwaggerPath, context, version, versionType);
         String apiXml = apiGenerator.generateSynapseAPIXml();
         return apiXml;
     }
 
-    private GenerateAPIResponse createAPIFromWSDL(String apiName, String endpoint, String sourcePath) throws SOAPToRESTException, MalformedURLException, JsonProcessingException, TransformerException {
+    private GenerateAPIResponse createAPIFromWSDL(String apiName, String endpoint, String sourcePath, String context, String version, String versionType) throws SOAPToRESTException, MalformedURLException, JsonProcessingException, TransformerException {
 
         URL url = new URL(sourcePath);
         SOAPtoRESTConversionData soaPtoRESTConversionData = SOAPToRESTConverter.getSOAPtoRESTConversionData(url,
@@ -191,7 +198,7 @@ public class RestApiAdmin {
         wsdlEndpoint.setWsdl(wsdlEndpointData);
 
         String swaggerYaml = soaPtoRESTConversionData.getOASString();
-        String apiXml = getSynapseAPIFromSwagger(swaggerYaml, null);
+        String apiXml = getSynapseAPIFromSwagger(swaggerYaml, null, context, version, versionType);
         APIFactory apiFactory = new APIFactory();
         API api = (API) apiFactory.create(Utils.getDOMDocument(apiXml).getDocumentElement());
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/SwaggerConstants.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/SwaggerConstants.java
@@ -190,4 +190,9 @@ public class SwaggerConstants {
      *  Path param normaized placeholder
      */
     public static final String NORMALIZED_PLACEHOLDER = "{}";
+
+    /**
+     * Version type value indicating that the API should be unversioned
+     */
+    static final String VERSION_TYPE_NONE = "none";
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/pojo/GenerateAPIParam.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/customservice/synapse/api/generator/pojo/GenerateAPIParam.java
@@ -21,4 +21,7 @@ public class GenerateAPIParam {
     public String wsdlEndpointName;
     public String publishSwaggerPath;
     public String mode;
+    public String context;
+    public String version;
+    public String versionType;
 }


### PR DESCRIPTION
This PR will give priority to the user given context and version when generating an API via an OpenAPI definition. This will also remove the existing behaviour of modifying query params in an OpenAPI definition based on the url-mapping of a resource.